### PR TITLE
Add missing BOM for soldering 0.03.12

### DIFF
--- a/OpenBikeSensor03/generated/BOM_for_soldering_Rev_0.03.12.html
+++ b/OpenBikeSensor03/generated/BOM_for_soldering_Rev_0.03.12.html
@@ -1,0 +1,4345 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interactive BOM for KiCAD</title>
+  <style type="text/css">
+:root {
+  --pcb-edge-color: black;
+  --pad-color: #878787;
+  --pad-hole-color: #CCCCCC;
+  --pad-color-highlight: #D04040;
+  --pad-color-highlight-both: #D0D040;
+  --pad-color-highlight-marked: #44a344;
+  --pin1-outline-color: #ffb629;
+  --pin1-outline-color-highlight: #ffb629;
+  --pin1-outline-color-highlight-both: #fcbb39;
+  --pin1-outline-color-highlight-marked: #fdbe41;
+  --silkscreen-edge-color: #aa4;
+  --silkscreen-polygon-color: #4aa;
+  --silkscreen-text-color: #4aa;
+  --fabrication-edge-color: #907651;
+  --fabrication-polygon-color: #907651;
+  --fabrication-text-color: #a27c24;
+  --track-color: #def5f1;
+  --track-color-highlight: #D04040;
+  --zone-color: #def5f1;
+  --zone-color-highlight: #d0404080;
+}
+
+html,
+body {
+  margin: 0px;
+  height: 100%;
+  font-family: Verdana, sans-serif;
+}
+
+.dark.topmostdiv {
+  --pcb-edge-color: #eee;
+  --pad-color: #808080;
+  --pin1-outline-color: #ffa800;
+  --pin1-outline-color-highlight: #ccff00;
+  --track-color: #42524f;
+  --zone-color: #42524f;
+  background-color: #252c30;
+  color: #eee;
+}
+
+button {
+  background-color: #eee;
+  border: 1px solid #888;
+  color: black;
+  height: 44px;
+  width: 44px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: bolder;
+}
+
+.dark button {
+  /* This will be inverted */
+  background-color: #c3b7b5;
+}
+
+button.depressed {
+  background-color: #0a0;
+  color: white;
+}
+
+.dark button.depressed {
+  /* This will be inverted */
+  background-color: #b3b;
+}
+
+button:focus {
+  outline: 0;
+}
+
+button#tb-btn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8.47 8.47'%3E%3Crect transform='translate(0 -288.53)' ry='1.17' y='288.8' x='.27' height='7.94' width='7.94' fill='%23f9f9f9'/%3E%3Cg transform='translate(0 -288.53)'%3E%3Crect width='7.94' height='7.94' x='.27' y='288.8' ry='1.17' fill='none' stroke='%23000' stroke-width='.4' stroke-linejoin='round'/%3E%3Cpath d='M1.32 290.12h5.82M1.32 291.45h5.82' fill='none' stroke='%23000' stroke-width='.4'/%3E%3Cpath d='M4.37 292.5v4.23M.26 292.63H8.2' fill='none' stroke='%23000' stroke-width='.3'/%3E%3Ctext font-weight='700' font-size='3.17' font-family='sans-serif'%3E%3Ctspan x='1.35' y='295.73'%3EF%3C/tspan%3E%3Ctspan x='5.03' y='295.68'%3EB%3C/tspan%3E%3C/text%3E%3C/g%3E%3C/svg%3E%0A");
+}
+
+button#lr-btn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8.47 8.47'%3E%3Crect transform='translate(0 -288.53)' ry='1.17' y='288.8' x='.27' height='7.94' width='7.94' fill='%23f9f9f9'/%3E%3Cg transform='translate(0 -288.53)'%3E%3Crect width='7.94' height='7.94' x='.27' y='288.8' ry='1.17' fill='none' stroke='%23000' stroke-width='.4' stroke-linejoin='round'/%3E%3Cpath d='M1.06 290.12H3.7m-2.64 1.33H3.7m-2.64 1.32H3.7m-2.64 1.3H3.7m-2.64 1.33H3.7' fill='none' stroke='%23000' stroke-width='.4'/%3E%3Cpath d='M4.37 288.8v7.94m0-4.11h3.96' fill='none' stroke='%23000' stroke-width='.3'/%3E%3Ctext font-weight='700' font-size='3.17' font-family='sans-serif'%3E%3Ctspan x='5.11' y='291.96'%3EF%3C/tspan%3E%3Ctspan x='5.03' y='295.68'%3EB%3C/tspan%3E%3C/text%3E%3C/g%3E%3C/svg%3E%0A");
+}
+
+button#bom-btn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8.47 8.47'%3E%3Crect transform='translate(0 -288.53)' ry='1.17' y='288.8' x='.27' height='7.94' width='7.94' fill='%23f9f9f9'/%3E%3Cg transform='translate(0 -288.53)' fill='none' stroke='%23000' stroke-width='.4'%3E%3Crect width='7.94' height='7.94' x='.27' y='288.8' ry='1.17' stroke-linejoin='round'/%3E%3Cpath d='M1.59 290.12h5.29M1.59 291.45h5.33M1.59 292.75h5.33M1.59 294.09h5.33M1.59 295.41h5.33'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+button#bom-grouped-btn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Cg stroke='%23000' stroke-linejoin='round' class='layer'%3E%3Crect width='29' height='29' x='1.5' y='1.5' stroke-width='2' fill='%23fff' rx='5' ry='5'/%3E%3Cpath stroke-linecap='square' stroke-width='2' d='M6 10h4m4 0h5m4 0h3M6.1 22h3m3.9 0h5m4 0h4m-16-8h4m4 0h4'/%3E%3Cpath stroke-linecap='null' d='M5 17.5h22M5 26.6h22M5 5.5h22'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+button#bom-ungrouped-btn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Cg stroke='%23000' stroke-linejoin='round' class='layer'%3E%3Crect width='29' height='29' x='1.5' y='1.5' stroke-width='2' fill='%23fff' rx='5' ry='5'/%3E%3Cpath stroke-linecap='square' stroke-width='2' d='M6 10h4m-4 8h3m-3 8h4'/%3E%3Cpath stroke-linecap='null' d='M5 13.5h22m-22 8h22M5 5.5h22'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+button#bom-netlist-btn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Cg fill='none' stroke='%23000' class='layer'%3E%3Crect width='29' height='29' x='1.5' y='1.5' stroke-width='2' fill='%23fff' rx='5' ry='5'/%3E%3Cpath stroke-width='2' d='M6 26l6-6v-8m13.8-6.3l-6 6v8'/%3E%3Ccircle cx='11.8' cy='9.5' r='2.8' stroke-width='2'/%3E%3Ccircle cx='19.8' cy='22.8' r='2.8' stroke-width='2'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+button#copy {
+  background-image: url("data:image/svg+xml,%3Csvg height='48' viewBox='0 0 48 48' width='48' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 0h48v48h-48z' fill='none'/%3E%3Cpath d='M32 2h-24c-2.21 0-4 1.79-4 4v28h4v-28h24v-4zm6 8h-22c-2.21 0-4 1.79-4 4v28c0 2.21 1.79 4 4 4h22c2.21 0 4-1.79 4-4v-28c0-2.21-1.79-4-4-4zm0 32h-22v-28h22v28z'/%3E%3C/svg%3E");
+  background-position: 6px 6px;
+  background-repeat: no-repeat;
+  background-size: 26px 26px;
+  border-radius: 6px;
+  height: 40px;
+  width: 40px;
+  margin: 10px 5px;
+}
+
+button#copy:active {
+  box-shadow: inset 0px 0px 5px #6c6c6c;
+}
+
+textarea.clipboard-temp {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 2em;
+  height: 2em;
+  padding: 0;
+  border: None;
+  outline: None;
+  box-shadow: None;
+  background: transparent;
+}
+
+.left-most-button {
+  border-right: 0;
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+}
+
+.middle-button {
+  border-right: 0;
+}
+
+.right-most-button {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.button-container {
+  font-size: 0;
+  margin: 10px 10px 10px 0px;
+}
+
+.dark .button-container {
+  filter: invert(1);
+}
+
+.button-container button {
+  background-size: 32px 32px;
+  background-position: 5px 5px;
+  background-repeat: no-repeat;
+}
+
+@media print {
+  .hideonprint {
+    display: none;
+  }
+}
+
+canvas {
+  cursor: crosshair;
+}
+
+canvas:active {
+  cursor: grabbing;
+}
+
+.fileinfo {
+  width: 100%;
+  max-width: 1000px;
+  border: none;
+  padding: 5px;
+}
+
+.fileinfo .title {
+  font-size: 20pt;
+  font-weight: bold;
+}
+
+.fileinfo td {
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 1px;
+  width: 50%;
+  text-overflow: ellipsis;
+}
+
+.bom {
+  border-collapse: collapse;
+  font-family: Consolas, "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 10pt;
+  table-layout: fixed;
+  width: 100%;
+  margin-top: 1px;
+  position: relative;
+}
+
+.bom th,
+.bom td {
+  border: 1px solid black;
+  padding: 5px;
+  word-wrap: break-word;
+  text-align: center;
+  position: relative;
+}
+
+.dark .bom th,
+.dark .bom td {
+  border: 1px solid #777;
+}
+
+.bom th {
+  background-color: #CCCCCC;
+  background-clip: padding-box;
+}
+
+.dark .bom th {
+  background-color: #3b4749;
+}
+
+.bom tr.highlighted:nth-child(n) {
+  background-color: #cfc;
+}
+
+.dark .bom tr.highlighted:nth-child(n) {
+  background-color: #226022;
+}
+
+.bom tr:nth-child(even) {
+  background-color: #f2f2f2;
+}
+
+.dark .bom tr:nth-child(even) {
+  background-color: #313b40;
+}
+
+.bom tr.checked {
+  color: #1cb53d;
+}
+
+.dark .bom tr.checked {
+  color: #2cce54;
+}
+
+.bom tr {
+  transition: background-color 0.2s;
+}
+
+.bom .numCol {
+  width: 30px;
+}
+
+.bom .value {
+  width: 15%;
+}
+
+.bom .quantity {
+  width: 65px;
+}
+
+.bom th .sortmark {
+  position: absolute;
+  right: 1px;
+  top: 1px;
+  margin-top: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent #221 transparent;
+  transform-origin: 50% 85%;
+  transition: opacity 0.2s, transform 0.4s;
+}
+
+.dark .bom th .sortmark {
+  filter: invert(1);
+}
+
+.bom th .sortmark.none {
+  opacity: 0;
+}
+
+.bom th .sortmark.desc {
+  transform: rotate(180deg);
+}
+
+.bom th:hover .sortmark.none {
+  opacity: 0.5;
+}
+
+.bom .bom-checkbox {
+  width: 30px;
+  position: relative;
+  user-select: none;
+  -moz-user-select: none;
+}
+
+.bom .bom-checkbox:before {
+  content: "";
+  position: absolute;
+  border-width: 15px;
+  border-style: solid;
+  border-color: #51829f transparent transparent transparent;
+  visibility: hidden;
+  top: -15px;
+}
+
+.bom .bom-checkbox:after {
+  content: "Double click to set/unset all";
+  position: absolute;
+  color: white;
+  top: -35px;
+  left: -26px;
+  background: #51829f;
+  padding: 5px 15px;
+  border-radius: 8px;
+  white-space: nowrap;
+  visibility: hidden;
+}
+
+.bom .bom-checkbox:hover:before,
+.bom .bom-checkbox:hover:after {
+  visibility: visible;
+  transition: visibility 0.2s linear 1s;
+}
+
+.split {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background-color: inherit;
+}
+
+.split.split-horizontal,
+.gutter.gutter-horizontal {
+  height: 100%;
+  float: left;
+}
+
+.gutter {
+  background-color: #ddd;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  transition: background-color 0.3s;
+}
+
+.dark .gutter {
+  background-color: #777;
+}
+
+.gutter.gutter-horizontal {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+  cursor: ew-resize;
+  width: 5px;
+}
+
+.gutter.gutter-vertical {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAFAQMAAABo7865AAAABlBMVEVHcEzMzMzyAv2sAAAAAXRSTlMAQObYZgAAABBJREFUeF5jOAMEEAIEEFwAn3kMwcB6I2AAAAAASUVORK5CYII=');
+  cursor: ns-resize;
+  height: 5px;
+}
+
+.searchbox {
+  float: left;
+  height: 40px;
+  margin: 10px 5px;
+  padding: 12px 32px;
+  font-family: Consolas, "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 18px;
+  box-sizing: border-box;
+  border: 1px solid #888;
+  border-radius: 6px;
+  outline: none;
+  background-color: #eee;
+  transition: background-color 0.2s, border 0.2s;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABNklEQVQ4T8XSMUvDQBQH8P/LElFa/AIZHcTBQSz0I/gFstTBRR2KUC4ldDxw7h0Bl3RRUATxi4iiODgoiLNrbQYp5J6cpJJqomkX33Z37/14d/dIa33MzDuYI4johOI4XhyNRteO46zNYjDzAxE1yBZprVeZ+QbAUhXEGJMA2Ox2u4+fQIa0mPmsCgCgJYQ4t7lfgF0opQYAdv9ABkKI/UnOFCClXKjX61cA1osQY8x9kiRNKeV7IWA3oyhaSdP0FkAtjxhj3hzH2RBCPOf3pzqYHCilfAAX+URm9oMguPzeWSGQvUcMYC8rOBJCHBRdqxTo9/vbRHRqi8bj8XKv1xvODbiuW2u32/bvf0SlDv4XYOY7z/Mavu+nM1+BmQ+NMc0wDF/LprP0DbTWW0T00ul0nn4b7Q87+X4Qmfiq2wAAAABJRU5ErkJggg==');
+  background-position: 10px 10px;
+  background-repeat: no-repeat;
+}
+
+.dark .searchbox {
+  background-color: #111;
+  color: #eee;
+}
+
+.searchbox::placeholder {
+  color: #ccc;
+}
+
+.dark .searchbox::placeholder {
+  color: #666;
+}
+
+.filter {
+  width: calc(60% - 64px);
+}
+
+.reflookup {
+  width: calc(40% - 10px);
+}
+
+input[type=text]:focus {
+  background-color: white;
+  border: 1px solid #333;
+}
+
+.dark input[type=text]:focus {
+  background-color: #333;
+  border: 1px solid #ccc;
+}
+
+mark.highlight {
+  background-color: #5050ff;
+  color: #fff;
+  padding: 2px;
+  border-radius: 6px;
+}
+
+.dark mark.highlight {
+  background-color: #76a6da;
+  color: #111;
+}
+
+.menubtn {
+  background-color: white;
+  border: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='36' viewBox='0 0 20 20'%3E%3Cpath fill='none' d='M0 0h20v20H0V0z'/%3E%3Cpath d='M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z'/%3E%3C/svg%3E%0A");
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.statsbtn {
+  background-color: white;
+  border: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='36' height='36' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6h28v24H4V6zm0 8h28v8H4m9-16v24h10V5.8' fill='none' stroke='%23000' stroke-width='2'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.iobtn {
+  background-color: white;
+  border: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='36'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' d='M3 33v-7l6.8-7h16.5l6.7 7v7H3zM3.2 26H33M21 9l5-5.9 5 6h-2.5V15h-5V9H21zm-4.9 0l-5 6-5-6h2.5V3h5v6h2.5z'/%3E%3Cpath fill='none' stroke='%23000' d='M6.1 29.5H10'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.visbtn {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath fill='none' stroke='%23333' d='M2.5 4.5h5v15h-5zM9.5 4.5h5v15h-5zM16.5 4.5h5v15h-5z'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  padding: 15px;
+}
+
+#vismenu-content {
+  left: 0px;
+  font-family: Verdana, sans-serif;
+}
+
+.dark .statsbtn,
+.dark .savebtn,
+.dark .menubtn,
+.dark .iobtn,
+.dark .visbtn {
+  filter: invert(1);
+}
+
+.flexbox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.savebtn {
+  background-color: #d6d6d6;
+  width: auto;
+  height: 30px;
+  flex-grow: 1;
+  margin: 5px;
+  border-radius: 4px;
+}
+
+.savebtn:active {
+  background-color: #0a0;
+  color: white;
+}
+
+.dark .savebtn:active {
+  /* This will be inverted */
+  background-color: #b3b;
+}
+
+.stats {
+  border-collapse: collapse;
+  font-size: 12pt;
+  table-layout: fixed;
+  width: 100%;
+  min-width: 450px;
+}
+
+.dark .stats td {
+  border: 1px solid #bbb;
+}
+
+.stats td {
+  border: 1px solid black;
+  padding: 5px;
+  word-wrap: break-word;
+  text-align: center;
+  position: relative;
+}
+
+#checkbox-stats div {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#checkbox-stats .bar {
+  background-color: rgba(28, 251, 0, 0.6);
+}
+
+.menu {
+  position: relative;
+  display: inline-block;
+  margin: 10px 10px 10px 0px;
+}
+
+.menu-content {
+  font-size: 12pt !important;
+  text-align: left !important;
+  font-weight: normal !important;
+  display: none;
+  position: absolute;
+  background-color: white;
+  right: 0;
+  min-width: 300px;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+  padding: 8px;
+}
+
+.dark .menu-content {
+  background-color: #111;
+}
+
+.menu:hover .menu-content {
+  display: block;
+}
+
+.menu:hover .menubtn,
+.menu:hover .iobtn,
+.menu:hover .statsbtn {
+  background-color: #eee;
+}
+
+.menu-label {
+  display: inline-block;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-top: 0;
+  width: calc(100% - 18px);
+}
+
+.menu-label-top {
+  border-top: 1px solid #ccc;
+}
+
+.menu-textbox {
+  float: left;
+  height: 24px;
+  margin: 10px 5px;
+  padding: 5px 5px;
+  font-family: Consolas, "DejaVu Sans Mono", Monaco, monospace;
+  font-size: 14px;
+  box-sizing: border-box;
+  border: 1px solid #888;
+  border-radius: 4px;
+  outline: none;
+  background-color: #eee;
+  transition: background-color 0.2s, border 0.2s;
+  width: calc(100% - 10px);
+}
+
+.menu-textbox.invalid,
+.dark .menu-textbox.invalid {
+  color: red;
+}
+
+.dark .menu-textbox {
+  background-color: #222;
+  color: #eee;
+}
+
+.radio-container {
+  margin: 4px;
+}
+
+.topmostdiv {
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  transition: background-color 0.3s;
+}
+
+#top {
+  height: 78px;
+  border-bottom: 2px solid black;
+}
+
+.dark #top {
+  border-bottom: 2px solid #ccc;
+}
+
+#dbg {
+  display: block;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #aaa;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #666;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+.slider {
+  -webkit-appearance: none;
+  width: 100%;
+  margin: 3px 0;
+  padding: 0;
+  outline: none;
+  opacity: 0.7;
+  -webkit-transition: .2s;
+  transition: opacity .2s;
+  border-radius: 3px;
+}
+
+.slider:hover {
+  opacity: 1;
+}
+
+.slider:focus {
+  outline: none;
+}
+
+.slider::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 8px;
+  background: #d3d3d3;
+  border-radius: 3px;
+  border: none;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #0a0;
+  cursor: pointer;
+  margin-top: -4px;
+}
+
+.dark .slider::-webkit-slider-thumb {
+  background: #3d3;
+}
+
+.slider::-moz-range-thumb {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #0a0;
+  cursor: pointer;
+}
+
+.slider::-moz-range-track {
+  height: 8px;
+  background: #d3d3d3;
+  border-radius: 3px;
+}
+
+.dark .slider::-moz-range-thumb {
+  background: #3d3;
+}
+
+.slider::-ms-track {
+  width: 100%;
+  height: 8px;
+  border-width: 3px 0;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+  transition: opacity .2s;
+}
+
+.slider::-ms-fill-lower {
+  background: #d3d3d3;
+  border: none;
+  border-radius: 3px;
+}
+
+.slider::-ms-fill-upper {
+  background: #d3d3d3;
+  border: none;
+  border-radius: 3px;
+}
+
+.slider::-ms-thumb {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: #0a0;
+  cursor: pointer;
+  margin: 0;
+}
+
+.shameless-plug {
+  font-size: 0.8em;
+  text-align: center;
+  display: block;
+}
+
+a {
+  color: #0278a4;
+}
+
+.dark a {
+  color: #00b9fd;
+}
+
+#frontcanvas,
+#backcanvas {
+  touch-action: none;
+}
+
+.placeholder {
+  border: 1px dashed #9f9fda !important;
+  background-color: #edf2f7 !important;
+}
+
+.dragging {
+  z-index: 999;
+}
+
+.dark .dragging>table>tbody>tr {
+  background-color: #252c30;
+}
+
+.dark .placeholder {
+  filter: invert(1);
+}
+
+.column-spacer {
+  top: 0;
+  left: 0;
+  width: calc(100% - 4px);
+  position: absolute;
+  cursor: pointer;
+  user-select: none;
+  height: 100%;
+}
+
+.column-width-handle {
+  top: 0;
+  right: 0;
+  width: 4px;
+  position: absolute;
+  cursor: col-resize;
+  user-select: none;
+  height: 100%;
+}
+
+.column-width-handle:hover {
+  background-color: #4f99bd;
+}
+
+
+  </style>
+  <script type="text/javascript" >
+///////////////////////////////////////////////
+/*
+  Split.js - v1.3.5
+  MIT License
+  https://github.com/nathancahill/Split.js
+*/
+!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?module.exports=t():"function"==typeof define&&define.amd?define(t):e.Split=t()}(this,function(){"use strict";var e=window,t=e.document,n="addEventListener",i="removeEventListener",r="getBoundingClientRect",s=function(){return!1},o=e.attachEvent&&!e[n],a=["","-webkit-","-moz-","-o-"].filter(function(e){var n=t.createElement("div");return n.style.cssText="width:"+e+"calc(9px)",!!n.style.length}).shift()+"calc",l=function(e){return"string"==typeof e||e instanceof String?t.querySelector(e):e};return function(u,c){function z(e,t,n){var i=A(y,t,n);Object.keys(i).forEach(function(t){return e.style[t]=i[t]})}function h(e,t){var n=B(y,t);Object.keys(n).forEach(function(t){return e.style[t]=n[t]})}function f(e){var t=E[this.a],n=E[this.b],i=t.size+n.size;t.size=e/this.size*i,n.size=i-e/this.size*i,z(t.element,t.size,this.aGutterSize),z(n.element,n.size,this.bGutterSize)}function m(e){var t;this.dragging&&((t="touches"in e?e.touches[0][b]-this.start:e[b]-this.start)<=E[this.a].minSize+M+this.aGutterSize?t=E[this.a].minSize+this.aGutterSize:t>=this.size-(E[this.b].minSize+M+this.bGutterSize)&&(t=this.size-(E[this.b].minSize+this.bGutterSize)),f.call(this,t),c.onDrag&&c.onDrag())}function g(){var e=E[this.a].element,t=E[this.b].element;this.size=e[r]()[y]+t[r]()[y]+this.aGutterSize+this.bGutterSize,this.start=e[r]()[G]}function d(){var t=this,n=E[t.a].element,r=E[t.b].element;t.dragging&&c.onDragEnd&&c.onDragEnd(),t.dragging=!1,e[i]("mouseup",t.stop),e[i]("touchend",t.stop),e[i]("touchcancel",t.stop),t.parent[i]("mousemove",t.move),t.parent[i]("touchmove",t.move),delete t.stop,delete t.move,n[i]("selectstart",s),n[i]("dragstart",s),r[i]("selectstart",s),r[i]("dragstart",s),n.style.userSelect="",n.style.webkitUserSelect="",n.style.MozUserSelect="",n.style.pointerEvents="",r.style.userSelect="",r.style.webkitUserSelect="",r.style.MozUserSelect="",r.style.pointerEvents="",t.gutter.style.cursor="",t.parent.style.cursor=""}function S(t){var i=this,r=E[i.a].element,o=E[i.b].element;!i.dragging&&c.onDragStart&&c.onDragStart(),t.preventDefault(),i.dragging=!0,i.move=m.bind(i),i.stop=d.bind(i),e[n]("mouseup",i.stop),e[n]("touchend",i.stop),e[n]("touchcancel",i.stop),i.parent[n]("mousemove",i.move),i.parent[n]("touchmove",i.move),r[n]("selectstart",s),r[n]("dragstart",s),o[n]("selectstart",s),o[n]("dragstart",s),r.style.userSelect="none",r.style.webkitUserSelect="none",r.style.MozUserSelect="none",r.style.pointerEvents="none",o.style.userSelect="none",o.style.webkitUserSelect="none",o.style.MozUserSelect="none",o.style.pointerEvents="none",i.gutter.style.cursor=j,i.parent.style.cursor=j,g.call(i)}function v(e){e.forEach(function(t,n){if(n>0){var i=F[n-1],r=E[i.a],s=E[i.b];r.size=e[n-1],s.size=t,z(r.element,r.size,i.aGutterSize),z(s.element,s.size,i.bGutterSize)}})}function p(){F.forEach(function(e){e.parent.removeChild(e.gutter),E[e.a].element.style[y]="",E[e.b].element.style[y]=""})}void 0===c&&(c={});var y,b,G,E,w=l(u[0]).parentNode,D=e.getComputedStyle(w).flexDirection,U=c.sizes||u.map(function(){return 100/u.length}),k=void 0!==c.minSize?c.minSize:100,x=Array.isArray(k)?k:u.map(function(){return k}),L=void 0!==c.gutterSize?c.gutterSize:10,M=void 0!==c.snapOffset?c.snapOffset:30,O=c.direction||"horizontal",j=c.cursor||("horizontal"===O?"ew-resize":"ns-resize"),C=c.gutter||function(e,n){var i=t.createElement("div");return i.className="gutter gutter-"+n,i},A=c.elementStyle||function(e,t,n){var i={};return"string"==typeof t||t instanceof String?i[e]=t:i[e]=o?t+"%":a+"("+t+"% - "+n+"px)",i},B=c.gutterStyle||function(e,t){return n={},n[e]=t+"px",n;var n};"horizontal"===O?(y="width","clientWidth",b="clientX",G="left","paddingLeft"):"vertical"===O&&(y="height","clientHeight",b="clientY",G="top","paddingTop");var F=[];return E=u.map(function(e,t){var i,s={element:l(e),size:U[t],minSize:x[t]};if(t>0&&(i={a:t-1,b:t,dragging:!1,isFirst:1===t,isLast:t===u.length-1,direction:O,parent:w},i.aGutterSize=L,i.bGutterSize=L,i.isFirst&&(i.aGutterSize=L/2),i.isLast&&(i.bGutterSize=L/2),"row-reverse"===D||"column-reverse"===D)){var a=i.a;i.a=i.b,i.b=a}if(!o&&t>0){var c=C(t,O);h(c,L),c[n]("mousedown",S.bind(i)),c[n]("touchstart",S.bind(i)),w.insertBefore(c,s.element),i.gutter=c}0===t||t===u.length-1?z(s.element,s.size,L/2):z(s.element,s.size,L);var f=s.element[r]()[y];return f<s.minSize&&(s.minSize=f),t>0&&F.push(i),s}),o?{setSizes:v,destroy:p}:{setSizes:v,getSizes:function(){return E.map(function(e){return e.size})},collapse:function(e){if(e===F.length){var t=F[e-1];g.call(t),o||f.call(t,t.size-t.bGutterSize)}else{var n=F[e];g.call(n),o||f.call(n,n.aGutterSize)}},destroy:p}}});
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+// Copyright (c) 2013 Pieroxy <pieroxy@pieroxy.net>
+// This work is free. You can redistribute it and/or modify it
+// under the terms of the WTFPL, Version 2
+// For more information see LICENSE.txt or http://www.wtfpl.net/
+//
+// For more information, the home page:
+// http://pieroxy.net/blog/pages/lz-string/testing.html
+//
+// LZ-based compression algorithm, version 1.4.4
+var LZString=function(){var o=String.fromCharCode,i={};var n={decompressFromBase64:function(o){return null==o?"":""==o?null:n._decompress(o.length,32,function(n){return function(o,n){if(!i[o]){i[o]={};for(var t=0;t<o.length;t++)i[o][o.charAt(t)]=t}return i[o][n]}("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",o.charAt(n))})},_decompress:function(i,n,t){var r,e,a,s,p,u,l,f=[],c=4,d=4,h=3,v="",g=[],m={val:t(0),position:n,index:1};for(r=0;r<3;r+=1)f[r]=r;for(a=0,p=Math.pow(2,2),u=1;u!=p;)s=m.val&m.position,m.position>>=1,0==m.position&&(m.position=n,m.val=t(m.index++)),a|=(s>0?1:0)*u,u<<=1;switch(a){case 0:for(a=0,p=Math.pow(2,8),u=1;u!=p;)s=m.val&m.position,m.position>>=1,0==m.position&&(m.position=n,m.val=t(m.index++)),a|=(s>0?1:0)*u,u<<=1;l=o(a);break;case 1:for(a=0,p=Math.pow(2,16),u=1;u!=p;)s=m.val&m.position,m.position>>=1,0==m.position&&(m.position=n,m.val=t(m.index++)),a|=(s>0?1:0)*u,u<<=1;l=o(a);break;case 2:return""}for(f[3]=l,e=l,g.push(l);;){if(m.index>i)return"";for(a=0,p=Math.pow(2,h),u=1;u!=p;)s=m.val&m.position,m.position>>=1,0==m.position&&(m.position=n,m.val=t(m.index++)),a|=(s>0?1:0)*u,u<<=1;switch(l=a){case 0:for(a=0,p=Math.pow(2,8),u=1;u!=p;)s=m.val&m.position,m.position>>=1,0==m.position&&(m.position=n,m.val=t(m.index++)),a|=(s>0?1:0)*u,u<<=1;f[d++]=o(a),l=d-1,c--;break;case 1:for(a=0,p=Math.pow(2,16),u=1;u!=p;)s=m.val&m.position,m.position>>=1,0==m.position&&(m.position=n,m.val=t(m.index++)),a|=(s>0?1:0)*u,u<<=1;f[d++]=o(a),l=d-1,c--;break;case 2:return g.join("")}if(0==c&&(c=Math.pow(2,h),h++),f[l])v=f[l];else{if(l!==d)return null;v=e+e.charAt(0)}g.push(v),f[d++]=e+v.charAt(0),e=v,0==--c&&(c=Math.pow(2,h),h++)}}};return n}();"function"==typeof define&&define.amd?define(function(){return LZString}):"undefined"!=typeof module&&null!=module?module.exports=LZString:"undefined"!=typeof angular&&null!=angular&&angular.module("LZString",[]).factory("LZString",function(){return LZString});
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+/*!
+ * PEP v0.4.3 | https://github.com/jquery/PEP
+ * Copyright jQuery Foundation and other contributors | http://jquery.org/license
+ */
+!function(a,b){"object"==typeof exports&&"undefined"!=typeof module?module.exports=b():"function"==typeof define&&define.amd?define(b):a.PointerEventsPolyfill=b()}(this,function(){"use strict";function a(a,b){b=b||Object.create(null);var c=document.createEvent("Event");c.initEvent(a,b.bubbles||!1,b.cancelable||!1);
+for(var d,e=2;e<m.length;e++)d=m[e],c[d]=b[d]||n[e];c.buttons=b.buttons||0;
+var f=0;return f=b.pressure&&c.buttons?b.pressure:c.buttons?.5:0,c.x=c.clientX,c.y=c.clientY,c.pointerId=b.pointerId||0,c.width=b.width||0,c.height=b.height||0,c.pressure=f,c.tiltX=b.tiltX||0,c.tiltY=b.tiltY||0,c.twist=b.twist||0,c.tangentialPressure=b.tangentialPressure||0,c.pointerType=b.pointerType||"",c.hwTimestamp=b.hwTimestamp||0,c.isPrimary=b.isPrimary||!1,c}function b(){this.array=[],this.size=0}function c(a,b,c,d){this.addCallback=a.bind(d),this.removeCallback=b.bind(d),this.changedCallback=c.bind(d),A&&(this.observer=new A(this.mutationWatcher.bind(this)))}function d(a){return"body /shadow-deep/ "+e(a)}function e(a){return'[touch-action="'+a+'"]'}function f(a){return"{ -ms-touch-action: "+a+"; touch-action: "+a+"; }"}function g(){if(F){D.forEach(function(a){String(a)===a?(E+=e(a)+f(a)+"\n",G&&(E+=d(a)+f(a)+"\n")):(E+=a.selectors.map(e)+f(a.rule)+"\n",G&&(E+=a.selectors.map(d)+f(a.rule)+"\n"))});var a=document.createElement("style");a.textContent=E,document.head.appendChild(a)}}function h(){if(!window.PointerEvent){if(window.PointerEvent=a,window.navigator.msPointerEnabled){var b=window.navigator.msMaxTouchPoints;Object.defineProperty(window.navigator,"maxTouchPoints",{value:b,enumerable:!0}),u.registerSource("ms",_)}else Object.defineProperty(window.navigator,"maxTouchPoints",{value:0,enumerable:!0}),u.registerSource("mouse",N),void 0!==window.ontouchstart&&u.registerSource("touch",V);u.register(document)}}function i(a){if(!u.pointermap.has(a)){var b=new Error("InvalidPointerId");throw b.name="InvalidPointerId",b}}function j(a){for(var b=a.parentNode;b&&b!==a.ownerDocument;)b=b.parentNode;if(!b){var c=new Error("InvalidStateError");throw c.name="InvalidStateError",c}}function k(a){var b=u.pointermap.get(a);return 0!==b.buttons}function l(){window.Element&&!Element.prototype.setPointerCapture&&Object.defineProperties(Element.prototype,{setPointerCapture:{value:W},releasePointerCapture:{value:X},hasPointerCapture:{value:Y}})}
+var m=["bubbles","cancelable","view","detail","screenX","screenY","clientX","clientY","ctrlKey","altKey","shiftKey","metaKey","button","relatedTarget","pageX","pageY"],n=[!1,!1,null,null,0,0,0,0,!1,!1,!1,!1,0,null,0,0],o=window.Map&&window.Map.prototype.forEach,p=o?Map:b;b.prototype={set:function(a,b){return void 0===b?this["delete"](a):(this.has(a)||this.size++,void(this.array[a]=b))},has:function(a){return void 0!==this.array[a]},"delete":function(a){this.has(a)&&(delete this.array[a],this.size--)},get:function(a){return this.array[a]},clear:function(){this.array.length=0,this.size=0},forEach:function(a,b){return this.array.forEach(function(c,d){a.call(b,c,d,this)},this)}};var q=["bubbles","cancelable","view","detail","screenX","screenY","clientX","clientY","ctrlKey","altKey","shiftKey","metaKey","button","relatedTarget","buttons","pointerId","width","height","pressure","tiltX","tiltY","pointerType","hwTimestamp","isPrimary","type","target","currentTarget","which","pageX","pageY","timeStamp"],r=[!1,!1,null,null,0,0,0,0,!1,!1,!1,!1,0,null,0,0,0,0,0,0,0,"",0,!1,"",null,null,0,0,0,0],s={pointerover:1,pointerout:1,pointerenter:1,pointerleave:1},t="undefined"!=typeof SVGElementInstance,u={pointermap:new p,eventMap:Object.create(null),captureInfo:Object.create(null),eventSources:Object.create(null),eventSourceList:[],registerSource:function(a,b){var c=b,d=c.events;d&&(d.forEach(function(a){c[a]&&(this.eventMap[a]=c[a].bind(c))},this),this.eventSources[a]=c,this.eventSourceList.push(c))},register:function(a){for(var b,c=this.eventSourceList.length,d=0;d<c&&(b=this.eventSourceList[d]);d++)
+b.register.call(b,a)},unregister:function(a){for(var b,c=this.eventSourceList.length,d=0;d<c&&(b=this.eventSourceList[d]);d++)
+b.unregister.call(b,a)},contains:function(a,b){try{return a.contains(b)}catch(c){return!1}},down:function(a){a.bubbles=!0,this.fireEvent("pointerdown",a)},move:function(a){a.bubbles=!0,this.fireEvent("pointermove",a)},up:function(a){a.bubbles=!0,this.fireEvent("pointerup",a)},enter:function(a){a.bubbles=!1,this.fireEvent("pointerenter",a)},leave:function(a){a.bubbles=!1,this.fireEvent("pointerleave",a)},over:function(a){a.bubbles=!0,this.fireEvent("pointerover",a)},out:function(a){a.bubbles=!0,this.fireEvent("pointerout",a)},cancel:function(a){a.bubbles=!0,this.fireEvent("pointercancel",a)},leaveOut:function(a){this.out(a),this.propagate(a,this.leave,!1)},enterOver:function(a){this.over(a),this.propagate(a,this.enter,!0)},eventHandler:function(a){if(!a._handledByPE){var b=a.type,c=this.eventMap&&this.eventMap[b];c&&c(a),a._handledByPE=!0}},listen:function(a,b){b.forEach(function(b){this.addEvent(a,b)},this)},unlisten:function(a,b){b.forEach(function(b){this.removeEvent(a,b)},this)},addEvent:function(a,b){a.addEventListener(b,this.boundHandler)},removeEvent:function(a,b){a.removeEventListener(b,this.boundHandler)},makeEvent:function(b,c){this.captureInfo[c.pointerId]&&(c.relatedTarget=null);var d=new a(b,c);return c.preventDefault&&(d.preventDefault=c.preventDefault),d._target=d._target||c.target,d},fireEvent:function(a,b){var c=this.makeEvent(a,b);return this.dispatchEvent(c)},cloneEvent:function(a){for(var b,c=Object.create(null),d=0;d<q.length;d++)b=q[d],c[b]=a[b]||r[d],!t||"target"!==b&&"relatedTarget"!==b||c[b]instanceof SVGElementInstance&&(c[b]=c[b].correspondingUseElement);return a.preventDefault&&(c.preventDefault=function(){a.preventDefault()}),c},getTarget:function(a){var b=this.captureInfo[a.pointerId];return b?a._target!==b&&a.type in s?void 0:b:a._target},propagate:function(a,b,c){for(var d=a.target,e=[];d!==document&&!d.contains(a.relatedTarget);) if(e.push(d),d=d.parentNode,!d)return;c&&e.reverse(),e.forEach(function(c){a.target=c,b.call(this,a)},this)},setCapture:function(b,c,d){this.captureInfo[b]&&this.releaseCapture(b,d),this.captureInfo[b]=c,this.implicitRelease=this.releaseCapture.bind(this,b,d),document.addEventListener("pointerup",this.implicitRelease),document.addEventListener("pointercancel",this.implicitRelease);var e=new a("gotpointercapture");e.pointerId=b,e._target=c,d||this.asyncDispatchEvent(e)},releaseCapture:function(b,c){var d=this.captureInfo[b];if(d){this.captureInfo[b]=void 0,document.removeEventListener("pointerup",this.implicitRelease),document.removeEventListener("pointercancel",this.implicitRelease);var e=new a("lostpointercapture");e.pointerId=b,e._target=d,c||this.asyncDispatchEvent(e)}},dispatchEvent:/*scope.external.dispatchEvent || */function(a){var b=this.getTarget(a);if(b)return b.dispatchEvent(a)},asyncDispatchEvent:function(a){requestAnimationFrame(this.dispatchEvent.bind(this,a))}};u.boundHandler=u.eventHandler.bind(u);var v={shadow:function(a){if(a)return a.shadowRoot||a.webkitShadowRoot},canTarget:function(a){return a&&Boolean(a.elementFromPoint)},targetingShadow:function(a){var b=this.shadow(a);if(this.canTarget(b))return b},olderShadow:function(a){var b=a.olderShadowRoot;if(!b){var c=a.querySelector("shadow");c&&(b=c.olderShadowRoot)}return b},allShadows:function(a){for(var b=[],c=this.shadow(a);c;)b.push(c),c=this.olderShadow(c);return b},searchRoot:function(a,b,c){if(a){var d,e,f=a.elementFromPoint(b,c);for(e=this.targetingShadow(f);e;){if(d=e.elementFromPoint(b,c)){var g=this.targetingShadow(d);return this.searchRoot(g,b,c)||d} e=this.olderShadow(e)} return f}},owner:function(a){
+for(var b=a;b.parentNode;)b=b.parentNode;
+return b.nodeType!==Node.DOCUMENT_NODE&&b.nodeType!==Node.DOCUMENT_FRAGMENT_NODE&&(b=document),b},findTarget:function(a){var b=a.clientX,c=a.clientY,d=this.owner(a.target);
+return d.elementFromPoint(b,c)||(d=document),this.searchRoot(d,b,c)}},w=Array.prototype.forEach.call.bind(Array.prototype.forEach),x=Array.prototype.map.call.bind(Array.prototype.map),y=Array.prototype.slice.call.bind(Array.prototype.slice),z=Array.prototype.filter.call.bind(Array.prototype.filter),A=window.MutationObserver||window.WebKitMutationObserver,B="[touch-action]",C={subtree:!0,childList:!0,attributes:!0,attributeOldValue:!0,attributeFilter:["touch-action"]};c.prototype={watchSubtree:function(a){
+//
+this.observer&&v.canTarget(a)&&this.observer.observe(a,C)},enableOnSubtree:function(a){this.watchSubtree(a),a===document&&"complete"!==document.readyState?this.installOnLoad():this.installNewSubtree(a)},installNewSubtree:function(a){w(this.findElements(a),this.addElement,this)},findElements:function(a){return a.querySelectorAll?a.querySelectorAll(B):[]},removeElement:function(a){this.removeCallback(a)},addElement:function(a){this.addCallback(a)},elementChanged:function(a,b){this.changedCallback(a,b)},concatLists:function(a,b){return a.concat(y(b))},
+installOnLoad:function(){document.addEventListener("readystatechange",function(){"complete"===document.readyState&&this.installNewSubtree(document)}.bind(this))},isElement:function(a){return a.nodeType===Node.ELEMENT_NODE},flattenMutationTree:function(a){
+var b=x(a,this.findElements,this);
+return b.push(z(a,this.isElement)),b.reduce(this.concatLists,[])},mutationWatcher:function(a){a.forEach(this.mutationHandler,this)},mutationHandler:function(a){if("childList"===a.type){var b=this.flattenMutationTree(a.addedNodes);b.forEach(this.addElement,this);var c=this.flattenMutationTree(a.removedNodes);c.forEach(this.removeElement,this)}else"attributes"===a.type&&this.elementChanged(a.target,a.oldValue)}};var D=["none","auto","pan-x","pan-y",{rule:"pan-x pan-y",selectors:["pan-x pan-y","pan-y pan-x"]}],E="",F=window.PointerEvent||window.MSPointerEvent,G=!window.ShadowDOMPolyfill&&document.head.createShadowRoot,H=u.pointermap,I=25,J=[1,4,2,8,16],K=!1;try{K=1===new MouseEvent("test",{buttons:1}).buttons}catch(L){}
+var M,N={POINTER_ID:1,POINTER_TYPE:"mouse",events:["mousedown","mousemove","mouseup","mouseover","mouseout"],register:function(a){u.listen(a,this.events)},unregister:function(a){u.unlisten(a,this.events)},lastTouches:[],
+isEventSimulatedFromTouch:function(a){for(var b,c=this.lastTouches,d=a.clientX,e=a.clientY,f=0,g=c.length;f<g&&(b=c[f]);f++){
+var h=Math.abs(d-b.x),i=Math.abs(e-b.y);if(h<=I&&i<=I)return!0}},prepareEvent:function(a){var b=u.cloneEvent(a),c=b.preventDefault;return b.preventDefault=function(){a.preventDefault(),c()},b.pointerId=this.POINTER_ID,b.isPrimary=!0,b.pointerType=this.POINTER_TYPE,b},prepareButtonsForMove:function(a,b){var c=H.get(this.POINTER_ID);
+0!==b.which&&c?a.buttons=c.buttons:a.buttons=0,b.buttons=a.buttons},mousedown:function(a){if(!this.isEventSimulatedFromTouch(a)){var b=H.get(this.POINTER_ID),c=this.prepareEvent(a);K||(c.buttons=J[c.button],b&&(c.buttons|=b.buttons),a.buttons=c.buttons),H.set(this.POINTER_ID,a),b&&0!==b.buttons?u.move(c):u.down(c)}},mousemove:function(a){if(!this.isEventSimulatedFromTouch(a)){var b=this.prepareEvent(a);K||this.prepareButtonsForMove(b,a),b.button=-1,H.set(this.POINTER_ID,a),u.move(b)}},mouseup:function(a){if(!this.isEventSimulatedFromTouch(a)){var b=H.get(this.POINTER_ID),c=this.prepareEvent(a);if(!K){var d=J[c.button];
+c.buttons=b?b.buttons&~d:0,a.buttons=c.buttons}H.set(this.POINTER_ID,a),
+c.buttons&=~J[c.button],0===c.buttons?u.up(c):u.move(c)}},mouseover:function(a){if(!this.isEventSimulatedFromTouch(a)){var b=this.prepareEvent(a);K||this.prepareButtonsForMove(b,a),b.button=-1,H.set(this.POINTER_ID,a),u.enterOver(b)}},mouseout:function(a){if(!this.isEventSimulatedFromTouch(a)){var b=this.prepareEvent(a);K||this.prepareButtonsForMove(b,a),b.button=-1,u.leaveOut(b)}},cancel:function(a){var b=this.prepareEvent(a);u.cancel(b),this.deactivateMouse()},deactivateMouse:function(){H["delete"](this.POINTER_ID)}},O=u.captureInfo,P=v.findTarget.bind(v),Q=v.allShadows.bind(v),R=u.pointermap,S=2500,T=200,U="touch-action",V={events:["touchstart","touchmove","touchend","touchcancel"],register:function(a){M.enableOnSubtree(a)},unregister:function(){},elementAdded:function(a){var b=a.getAttribute(U),c=this.touchActionToScrollType(b);c&&(a._scrollType=c,u.listen(a,this.events),
+Q(a).forEach(function(a){a._scrollType=c,u.listen(a,this.events)},this))},elementRemoved:function(a){a._scrollType=void 0,u.unlisten(a,this.events),
+Q(a).forEach(function(a){a._scrollType=void 0,u.unlisten(a,this.events)},this)},elementChanged:function(a,b){var c=a.getAttribute(U),d=this.touchActionToScrollType(c),e=this.touchActionToScrollType(b);
+d&&e?(a._scrollType=d,Q(a).forEach(function(a){a._scrollType=d},this)):e?this.elementRemoved(a):d&&this.elementAdded(a)},scrollTypes:{EMITTER:"none",XSCROLLER:"pan-x",YSCROLLER:"pan-y",SCROLLER:/^(?:pan-x pan-y)|(?:pan-y pan-x)|auto$/},touchActionToScrollType:function(a){var b=a,c=this.scrollTypes;return"none"===b?"none":b===c.XSCROLLER?"X":b===c.YSCROLLER?"Y":c.SCROLLER.exec(b)?"XY":void 0},POINTER_TYPE:"touch",firstTouch:null,isPrimaryTouch:function(a){return this.firstTouch===a.identifier},setPrimaryTouch:function(a){
+(0===R.size||1===R.size&&R.has(1))&&(this.firstTouch=a.identifier,this.firstXY={X:a.clientX,Y:a.clientY},this.scrolling=!1,this.cancelResetClickCount())},removePrimaryPointer:function(a){a.isPrimary&&(this.firstTouch=null,this.firstXY=null,this.resetClickCount())},clickCount:0,resetId:null,resetClickCount:function(){var a=function(){this.clickCount=0,this.resetId=null}.bind(this);this.resetId=setTimeout(a,T)},cancelResetClickCount:function(){this.resetId&&clearTimeout(this.resetId)},typeToButtons:function(a){var b=0;return"touchstart"!==a&&"touchmove"!==a||(b=1),b},touchToPointer:function(a){var b=this.currentTouchEvent,c=u.cloneEvent(a),d=c.pointerId=a.identifier+2;c.target=O[d]||P(c),c.bubbles=!0,c.cancelable=!0,c.detail=this.clickCount,c.button=0,c.buttons=this.typeToButtons(b.type),c.width=2*(a.radiusX||a.webkitRadiusX||0),c.height=2*(a.radiusY||a.webkitRadiusY||0),c.pressure=a.force||a.webkitForce||.5,c.isPrimary=this.isPrimaryTouch(a),c.pointerType=this.POINTER_TYPE,
+c.altKey=b.altKey,c.ctrlKey=b.ctrlKey,c.metaKey=b.metaKey,c.shiftKey=b.shiftKey;
+var e=this;return c.preventDefault=function(){e.scrolling=!1,e.firstXY=null,b.preventDefault()},c},processTouches:function(a,b){var c=a.changedTouches;this.currentTouchEvent=a;for(var d,e=0;e<c.length;e++)d=c[e],b.call(this,this.touchToPointer(d))},
+shouldScroll:function(a){if(this.firstXY){var b,c=a.currentTarget._scrollType;if("none"===c)
+b=!1;else if("XY"===c)
+b=!0;else{var d=a.changedTouches[0],e=c,f="Y"===c?"X":"Y",g=Math.abs(d["client"+e]-this.firstXY[e]),h=Math.abs(d["client"+f]-this.firstXY[f]);
+b=g>=h}return this.firstXY=null,b}},findTouch:function(a,b){for(var c,d=0,e=a.length;d<e&&(c=a[d]);d++)if(c.identifier===b)return!0},
+vacuumTouches:function(a){var b=a.touches;
+if(R.size>=b.length){var c=[];R.forEach(function(a,d){
+if(1!==d&&!this.findTouch(b,d-2)){var e=a.out;c.push(e)}},this),c.forEach(this.cancelOut,this)}},touchstart:function(a){this.vacuumTouches(a),this.setPrimaryTouch(a.changedTouches[0]),this.dedupSynthMouse(a),this.scrolling||(this.clickCount++,this.processTouches(a,this.overDown))},overDown:function(a){R.set(a.pointerId,{target:a.target,out:a,outTarget:a.target}),u.enterOver(a),u.down(a)},touchmove:function(a){this.scrolling||(this.shouldScroll(a)?(this.scrolling=!0,this.touchcancel(a)):(a.preventDefault(),this.processTouches(a,this.moveOverOut)))},moveOverOut:function(a){var b=a,c=R.get(b.pointerId);
+if(c){var d=c.out,e=c.outTarget;u.move(b),d&&e!==b.target&&(d.relatedTarget=b.target,b.relatedTarget=e,
+d.target=e,b.target?(u.leaveOut(d),u.enterOver(b)):(
+b.target=e,b.relatedTarget=null,this.cancelOut(b))),c.out=b,c.outTarget=b.target}},touchend:function(a){this.dedupSynthMouse(a),this.processTouches(a,this.upOut)},upOut:function(a){this.scrolling||(u.up(a),u.leaveOut(a)),this.cleanUpPointer(a)},touchcancel:function(a){this.processTouches(a,this.cancelOut)},cancelOut:function(a){u.cancel(a),u.leaveOut(a),this.cleanUpPointer(a)},cleanUpPointer:function(a){R["delete"](a.pointerId),this.removePrimaryPointer(a)},
+dedupSynthMouse:function(a){var b=N.lastTouches,c=a.changedTouches[0];
+if(this.isPrimaryTouch(c)){
+var d={x:c.clientX,y:c.clientY};b.push(d);var e=function(a,b){var c=a.indexOf(b);c>-1&&a.splice(c,1)}.bind(null,b,d);setTimeout(e,S)}}};M=new c(V.elementAdded,V.elementRemoved,V.elementChanged,V);var W,X,Y,Z=u.pointermap,$=window.MSPointerEvent&&"number"==typeof window.MSPointerEvent.MSPOINTER_TYPE_MOUSE,_={events:["MSPointerDown","MSPointerMove","MSPointerUp","MSPointerOut","MSPointerOver","MSPointerCancel","MSGotPointerCapture","MSLostPointerCapture"],register:function(a){u.listen(a,this.events)},unregister:function(a){u.unlisten(a,this.events)},POINTER_TYPES:["","unavailable","touch","pen","mouse"],prepareEvent:function(a){var b=a;return $&&(b=u.cloneEvent(a),b.pointerType=this.POINTER_TYPES[a.pointerType]),b},cleanup:function(a){Z["delete"](a)},MSPointerDown:function(a){Z.set(a.pointerId,a);var b=this.prepareEvent(a);u.down(b)},MSPointerMove:function(a){var b=this.prepareEvent(a);u.move(b)},MSPointerUp:function(a){var b=this.prepareEvent(a);u.up(b),this.cleanup(a.pointerId)},MSPointerOut:function(a){var b=this.prepareEvent(a);u.leaveOut(b)},MSPointerOver:function(a){var b=this.prepareEvent(a);u.enterOver(b)},MSPointerCancel:function(a){var b=this.prepareEvent(a);u.cancel(b),this.cleanup(a.pointerId)},MSLostPointerCapture:function(a){var b=u.makeEvent("lostpointercapture",a);u.dispatchEvent(b)},MSGotPointerCapture:function(a){var b=u.makeEvent("gotpointercapture",a);u.dispatchEvent(b)}},aa=window.navigator;aa.msPointerEnabled?(W=function(a){i(a),j(this),k(a)&&(u.setCapture(a,this,!0),this.msSetPointerCapture(a))},X=function(a){i(a),u.releaseCapture(a,!0),this.msReleasePointerCapture(a)}):(W=function(a){i(a),j(this),k(a)&&u.setCapture(a,this)},X=function(a){i(a),u.releaseCapture(a)}),Y=function(a){return!!u.captureInfo[a]},g(),h(),l();var ba={dispatcher:u,Installer:c,PointerEvent:a,PointerMap:p,targetFinding:v};return ba});
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+var config = {"dark_mode": true, "show_pads": true, "show_fabrication": false, "show_silkscreen": true, "highlight_pin1": false, "redraw_on_drag": true, "board_rotation": 0, "checkboxes": "Sourced,Placed", "bom_view": "left-right", "layer_view": "FB", "fields": ["Bemerkung", "Optional", "Value", "Footprint"]}
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+var pcbdata = JSON.parse(LZString.decompressFromBase64("N4IgpgJg5mDOD6AjRB7AHiAXAAlAWwEsA7DHAJgEYA6CgDgGYBOZgGmxEKIE8tsAWPlUYB2Ps0ZsOAQzSlstRlSb0ADCoqS8Mnjgp6qANgCstNRQC+kyDFi8A2qAAuXAA5heIWGCh4wRRyCSsI5SAE4BOHa0BlTRtGx61Ab09AC6VkQQ9gpKBvHYiYYp6ewA7gQQjgAWvCpUKkaWuCDObh5ePn4BQSHh2Yr0eWx8Mcwl4Jn9ufmFyWmS5ZU1OHUNTU6u7jie3r7+gezBYRHYUTFxw6OM435ZkTmD+SNC1wsV1bX1jWwbbdthAGMDp5eic7MJ6PVLvVxqEpBACABXWy6KGHUFSIhQAA2W2wAFpGKsMhBMTi8cSyu9lthVt9mq08SBAcCjn1IvRBCpoSpYfCkSiCmiQccybjeHRKRNSVjxeRhFLFh8Vl91i1Nu1dl1WaD7KI0XxhDCSXquTzxkqaXS1YzNZ19j1jvYUgajbyTRzIdz+DF3VSlp81j91X9DlqHeinRyzfwjMb2Lc9V7hnG/SBLYH6b8mR09t1I+zTi7vYb49L7JQqGQVBIfS8LdTMzaNdtc9rHYXwTHS2nE/dzkM62M3gGVUGGS2w/b8yLO5Xq7XmIZGEYbpNIvOawl9HMG6Paarg7bW+GZ2ywWQuSp6GwlwYV2u7qdN4vFPfVyPlQfx9m7XmdVGz7UAu0LDgm65AVWW7YBCVB8CoBh7l+1pHpOOzTgBc7AdBsHwYhHrPjGuEIUhVqHhOobof+HZgtEsSDrMxQEXYL7bkkTH+sh5G/ieGE0RWRGQnhj4CfU163m+D6fmRazjBAcLlFigqgLABDYgA1rAAKhGAfi8KAABi9igC4KCCnYRjAUYCRqFQwgfuwjhgGgJwgAAqgAygAQsCVRgAQUBVCcZDChm5DCgAVsijgEAAZjopzemm1QEAC6lEHAgp1De7BSI4jihPY4xihS9TNpRbYRrOYJGDEZDWQU15ln2py1VWDWMLQ7WkZ8FBkOVOanphYLPA1FBNb2EEWXVY0TT1Kp9QNf7tgWI0xB1XX1SJkSjTZXrzQei3BqZ5nwYY6i1m1RjCLQDktM5rkAEoABoALwAJIAPL0L5/mBSc1DeumjaokDUXBHFCV2El4wpWlGWwFlNANcy+WFZExWyqVKhqid9hnUY9C0HwbBGIIN03bDD0eAAKm9X0UL9AVBRKoUg0KYPRZD9gw5IcPpZlvUo3lBVFZIJWBrjZnOpCN1kGwBhGrQdBUy5Hj0EYTP/azQNhRzkjgzF8U82wyVVKlAuI0L4to2LuVY5Lx3S56dm0PL2DGFWlN89T2wUD9kh+czANs/ugMG1zxuRLzjnm/DgsLcLtsY+LDtjlL5kukStYGCFEK0KrrkAGoAHJayzoPSTrEcQ1HiWm7DceW0jFBJ6LKf2+SjvNHjG5CSuCshQYeiFx4RcAArlyHuvs+H7CG9z0cN3zTcIy3bfo6cmNd+nTvmWQkKPArSsqz7avbC9U/V5xNJzyAC919Dy+xxba/W7lydb6nO/fhnFb9w1T2ZBvaOV9uwOmV9K432vvfSOUMY4tFXgnQ6G87bMjTr/Pe2Q563TsqPbYABqegRd6AAB0iDkJpo9d6ABxch5CACiABhAAEp9ehRAaElwACLkMgQeYQVcVSCPnnAk2tJG6v2QXUVuNt25f07nKTBPdnanDopdUY+D2CPTAAAN1pKsSEfV+HUBRnrUxNcjbwOfogqRVsVTu1RvIuw28lFEjKlgjcMQ+AUAMGwYQMQFQFzPq5Lh3D+F1BEcDfckTLGL3rhIlediW71TkZvFx38lGrD/l4mgud/GQkJvMUB592BEJIREuyQiBFxMfgg/mb8FqpI/s41x2McnPhmreEKd0nKlJAOUgO7Ag7aygdEr8d8H7WMSS/eO9iUFpLQRLXeKjzLKyUKTEKfAtEgE+m4ChRAvIEHUmAchHk/CwBQIVQOf0K5CjMbPKgKMpniLNskz4jiRbpLabwdxONUIVSGvxDkXTsCMGoPZbaRZAkdRCltapMj+oAsGnxVazpQXgrsndFqdhBhYtvFZA6iKlq8WomikF+KwUQuxVNPFzTMWQoRTQJFFEUVkuquiylDKaVPlxYoDq1KiXMo6bi6le1YjRB2YM7AHkmEABlsBeTcjTbAYSZXcIAIKVKiXrWJoja7TLeXM9eiyO7oJ/tkzxpwfHtVvHUeFJTQk8I4QAWXeh5dhBz5UAGlXWfQ8u9DhTCPIcMGZU/I4yyIRpeUvGZtjjW9U+Z/DJij2lWpYjCtgdFelgJAC9Shz0TGhwmZFMRsajXN3fk475mS02rIrJmsFqwdlhKLTPMOpaDWvMkQmxOpqFHmqyR4+tuTmlu26iEjwYabnBxgeYztVju1JN7QslpNbU3dxMqorshhj7LgoC251BzmFsI4VQ2hobiFDJACMu5erI2fCiTGhJFbGmrurUsjBlqR1FmoGIPx/AupqHwo6qdRaHkdueWWl9PbK0qhyh+yIHACChFCFcyAIAfkrK3ZnP9jAANGFTDs/E4HqkWP1Yu8tsG33ZX7SmwddacN6kCXukD91+nnKIJc0IZA21kYXfEp+caGnSORnRrDTbh1MciPZNE6idmce44zGdoz9bQLGc+oTr7ROyLXZ+n+fyRUuhJo1AYOyvKInyigIg8AmHWYygCRwVy+PqbU7ArtVHl1wffV8/TQ7/k/umkIEY+RLJPNzgp8ojgAQ1BU3cu+87OYeZg15mjYm9NmuWco6Tz5FBkGiO7NqfV/bmZFmAUIPA4vT340lyjKXZneZkagzLX6pMgF7mow+/i6jbMnRfYQLmH0aeg1p6jOnmsDqy38yQOlYoShJVOdl55sg9JzpCA+ucjBkChVEVbg87L+1EME1zxLkXLSqst+4XINAe3W4Meq23mLE3qDd3OB36BHaFUdQLhGNmNS6sd9jT0DCDcS7Uw1Y35lNfE7WwMM2wBzd0AtqiK0OU7SNMkTb7txr8oPcxUsegPt8BmDWJ5eOTvCrO6S1Hl3rUY/u1tmyQHXjgV5QTw7xOmf1BZ0Nw6LKeKLZp7qe41BGA5QMDECgPOcXPcVgrSXPPdWU9Zeds8wu1GCDlx7BXO3ZciKMG+O6SvvsC5Rxd9XURNf68N7r0XOUDeGCN+zU7Kvqfm8AlEO3pMbdPa99rmgivnfK9N5VNXHuGB/Yl0INjMuuv+6l19/nIY2VC/D3HkwErdfp59xTk3yfVfDXsGFho24ZHCB28X2aRo+DFN5y7kPQLyWtUBlXuCtecUCDJzZavtfjdJ+PIL93nZO+WW723nbI+bt6DL4n5HofC87UEKPgo40aDl+YpX0va/Z9U8H2HzsYW3Zc8Bzizf/3Yg79d3vhf1rZYmfGgDifS+p8qEf0yvPHWLI9P8UaHN/SACKvGVWc6jytWgm9SSCUO6WiGk2rWQMs282u+Zu++NUdQJg/i3i0uU0YgjuGBcEgeMSwe+ebuKB+M1e7sAS+BE+XUGseBYgl+DeqKaOdOcEFBmBE+5B/iXUxgDBxB1+wKrUaB+QlB9BG+QhP+QgTuhBH+26Z0isr+zSleTAhGOybkymwyty08agRMAGvOgM2h0Q4OS6DWaW6gE29GWWUoCBSOSB8+AhuKv+DUW2SgPKzojht4NBX2WYfByBN+dgnsfAG0SgO2ARThIUGsXhc+jezB/hcYgRHhwRzEH2TyQRveQefUwgURTBtODhKRmyLhIRcRYRBR7+wCIql4TyCsPWOyAAUuNKDqAUYZ5iYeNjDhumOPDojgUFkUthbvVEIPZArNQBxOWByNQBQIMR7MMWkdIf3mhHYU3ixHGCIIAooCoOvqzs6OMZMfePUBsXXkQQPr4fYRUYTIAqLjtv0SsUMUILwUcQsTEVcTsdMZccsc8bcaUT0anp2PQNsecUoO3rSn8TcQQVxHnvcdETkU8YAl1K4RuG8asXsXcfMZCRbr8WvjCU8jtuiRMYiesciYCtkX0QiQrEJI9psfCQMYAoIAIASSnkPmCDiTsWSdicCR7DSb1rnnMYSb0R7tCQrMsTHlNPyf7p1HSQXvYUyYAoKayRifLkIIDn3kZlbjdoTEoJyUDh4NwkARobOmMmDhRuATYiJlAbpjARYXAZ0YgVfiAACChgCOKJKWsUwKFtlKYDznCAiMiLwHnI4kqbYaiR7nir8Z1KTG6TWNiXGLdKGdgEYOGaCWRDIeZFHvhsIKqXUCuJeDso9DqTepoSAR2mAXUsaZASahlrARasKNYd0QGUSR7skLEKILWKWGQPhhqTig2bQE2WGfUIMBqf6TaQ8TkZ2d2bGYYgYO2VNAqHBBQGID2deBOeKSQX4dOT4nOWOb2YucxKubOc2UaK2VuVyV8QyXqD1rucMPuW2SEZCF2euS2VeZ8bWbyZ2A2eNHedwRLpObyiOe+YYJ+UufwYsWmTQMTM2R+YeaMacDub+RLhBQOabqZNiFwFANZsCJ/mFiIgyhJtDGWIhchdZuZHYHYPiHULnMTiZiFOscIMIOScRaRcYJztgJRdRTRSUHRX+YRowO7OEeCj4mxSRRxbnLWFsoRl2eTuxRLtdCoBRWTjWIrPxfRSYHwNxSkU2ZyRJRLghDJQbmRSBhpckIwDJbnKYAnmwPpbdA1EPITAYPiWZQJRLqICIkPPnCRHZfRW7PkkxYYAoHxW5X+VxYTGwHnOoJQHpfZQqCMABnnONOoBsRJWmQFUFQdppSzvFYMIFV5TRRMbQMdvFVtr8UlTRWTLRfZcrJQDJRCPBCVn5fePdipUdsYOJQJWma3MPIVXkAIGFZEpyLOTdnnAFRGX5QEtJYOCFMrMwFtgpa7PhpZbEGIDlXFQJW7OsQPF5TlbOQ6uxbdKoNBCFOCoMNRVNTlWTOoElYZddNdFNeCgqMIMJQMYrIyqcAJYZWmeuV6A0MTMUuxSIIaFLmwF6PQNWKxX5cwDlTGV6GTBdfxYDHQLdTdl6DRSMOpfiIDCkHGfkF6MTKBdDfUMpa1f9dzq/spTjdJfVOsQTTWDWGKXZYDIjcvl6J1OsSVeMSoK2RTSuIDV9SjcyuoCZpjeCtTU9eMYESILWAjWQNWMjeMROVrl6GIB9rldzbiVtmLfUBLWTItdsRTDJcwBrIMDjRMeNBLWdRORMQbXkGVWdQbk1dLRLRMWdWIIETbTQORQfGdSkH1AbcAhLmdeNBrFLTQGYJ5WNcrEwKldzQhMPAbklcTMYOoCTfVDlSpaYAbrZULS9rOTXoVbxVxUdZjklROcpQ0HnYMElVRcDU9XUD5a/mXSxSVVXYZTXUKCMKoMjaRZeMTAkHBMkNJVNWRZ3V5eXdtqkKkMjnhShUQGhduhhQSngrDtHLhSgEhRPYRThdnIDbXdRbRVXQwFxZvRXThTlUwCpbVLdbnWZYDPeIYZlUUpKhfTQHQG7HdaYJePrffb4jWDlGNYEa/npeMfhusTJetVmffRLT4jRb7a/q/mxcBE7bQV5WLoMIZTA+1AtVFcFozXFcBMYKoOgyuESJNaAzg/llbeCig8AkTCMGdV2YXeQ5VUwBTa3JyLldg0UjlHLTWHfacFZOsYRhTXMK2eQ6oGLu7JjXoIQ9w1BAqOCuzYDWQH/SBdJdHdgAzQwMAig63BLckOzVtvIxo3rRjfUAoNJVg8yjRcYBTQwK3Ro31PhgBgjeNKY5/flvDV8L8bSffQhESAhBTaoIDSw7jZ/YY9ocTZ45w6IGdRCBLWxRmQEsPH1cFg0F9RmT4oZXgwhLOblRmZHQEjHUEo9YfWmQbk5bEBrJZDE6U/ZOTWtWoLdOpVXQ0NWPVQ9WnThdRWTPkHnI8HkBU02YdoVTWIdr0/IyIAXdta3L0zWNReg7BU0xU1fXrQXVtsU/M2LgbndROYRhCKs3QBY15ROazZ7WZaRUSFVQXYDYrOJaRQoLDQXXbZtdc+NRs1RQ5DhXkKIPbV5SYF2dE8c95XkHQElbVHjVk/80TECykD4tvf86/gk2IB01c95co1sv+vHX83kCYLOUlUwI7XFdc+gV5RrBLdePM7dJ03sVvfM/BE3cxZS+i9SzMN3dY38+vdjky73Sy84/vcPaPUgePahZIOhRCrPfsVljhWmPy1xvYERRHTjipUPSTWudy4q63H1Ni5pc7dJa3Izl5cpQEjXiq/nbq2feUzTbjRMTI18wfAEprbjZLV/SkcwJtRHcpak0CwoPVOHYDMpYZQ68PPIxy+ndJX2SpT3bdVzd64EVnfs51WFd66fUs3GUwIqwqMvkPLnPq4q2JQkxLtELaw0AhNRQXRCNbSTZZLps5SMMzV8GmRA/s2owoCTfeDZSU/eLdcrCTV2Xw5lRMbddW9PjWPVT4srIreMYMBc+1eCiYObYTPEZlZ1ESKOwHmRcnaoL4q89zRLcrLtfRE0xu9gwYTHWs12Tja2XoJeGdQfC9TjYDUoyU5mdWM7ZyGmRvQg9RQIEux9qzTrZ1DdBG0oDlbeYw4TMXWa/BJQMAhTfIzjjjfBB5SIgDQYbB0TJQK49eC1dWyFsYKrdeDXoecRX+tGVB27ETDjeWxCDh+ex4+nSB9G3tTlcO2R1CwoCba3FwwR08nh5yO7fVAU9zdZXLGddeAuGR5yNdMnZ1LOWR8AoZUAwxwfGR71UAzRR9bB2Lj4ug6BSGbB5pa+2NZLQwMh2A7NTdCYM68MVxb8Q66ILVNWyh/lhVRrMPAHVezq6tpyNA2a65/K3XaeyZegwq15/513S3YGxx+oIOyFz3QHRF3vYPb5yPWPUvfhZPYK9PcK1SnPe0YlIvcvQRdKzhRtRe/F3Szl3oB1cq38+VwPT0vlreRU7OVM0Cz62/WV3Eww18/eP7HpfagoT4/s6zXmxUwfGHTm+A1JDlw9iGWMxrMTMNyYGTOgwqBLtC/I+lRVSdR238567O9nZ1II9t4aEzTHTXrU8N8AqqzHW7PZKlb1whNdL7W7A83ksTBCA7XU6C/7Jkw6yIPlveBU5TddD90SCkMk7jSt/Y2JGd382oI0wh2JH1ITFNdeAtcD3GfJX5a/h9mmZEwLfXcynh7NSuHGZdX5a3KmXdZZx61NY/SW1d/ePllNZQA0LVCd4TILexWA74pp2oEUkz394VZxfz7dPeIL7VKB5Xcyszwk/ZOLxuzIhMcO4VQoGHTT8J27WtcS+o5j7dZZJp/lWFwJesQoEW2tVtrHcj8Tjd3k4rPhsj+T7dUe1Mz1y9goMi7EJmbd18LVG5xKg+TlwhChwkwtUTQD1xSIA6z8w/g13QHGUA47RL4V0TG7EAxB2i2V/lXR9NTRWD63I5TL9dFLl73n4xXnEL1V1thLtZ5QCuC7/7HjwXSD4aDH9ta25ttR+K1xdzwXdS1JzD1HaX4YJeFowDy4778PJJYi7FTdAXb4vj7Ff7Xc+V/P3Gbc/sxrOCk1asLdcd/s6ncTmr62WzfW1xc32TxMcAvVZQNdzT3badTfXL8L7VHdbLzZfL1WNa9xz2+sYNZLwuBZQXRW6td2Kj9aSuSzIoawt+yMMXGLndYM9FqiKMQBEy+aiVOQavMmAk2Kpi4uqRjPqOS3N71dMeZVcloF0l4ZFKuZAyDs3Wi4NdlKxXP9DQKq50CZKCrRLny2S4T0p65kGepl1FYYJxW4wSVqvWAgrgWBvnIhmIB86lc7A2DSQUlRGD+xQmkjeztfR6Q3ReqKDYdoaCMqzlLI6lP9JIL2ZDwq2nnSRtoIlqhsaK9kfQfgTPY5tsBbsFBnHxN4DNbovzSRnGWuoVVNGCjSyAEhyqFUa8yscSqYgv65NMqRTWiqYkGY+152RTVKnhkCI1dYgUuJNpoMcqs81qH2TmpoM8F6ATuMAmwa6woYx0yYxOAJkwBbbB9LIH2BIUoD7bJ1AiEHFBl+xxwx0iYdjFoYRnPYx01uGPZQUS0+ZjUiapgmQUoD0AadleNlW6OQ1jqrU84NlY+uQ3F5UNMqnNBTqA3kaBElug3Apv/S64zMIQWrDRh1QraGAghZtd+qkx8Sz9h4IgGxljVmrW1cSKDKmteCeFtsD+njYmJiyBYq1f+Yw9YvExPoacyYrw0QIsIhZg0vqtNeRjPy+aA1DKdQ9Yg/nwGXgHqrwq+uJC+ZfcvhkjBCF2VgG6sfqHEQEXkEG7yC4mrNTEY5RKYCBfuTjS5nCzY4gIyReQUZoSw+ba98RubapuEQPiQ1MRo1KsJ1GiAwj6gubCgYCOg4BdxB+ImUVF2ZaSNWyZMRUWFxEGqiSurFNgTaUlZcCi8GXLCvPQD6CCOB+XSIDK3tRExwhtLA+gJXRpSj7RTdBgUqM57WiAMLow3laJobKsdRCFM0al3YBCsqkvA7Cs2jS55cpWFonCubz04UsD69qVOiQLlE4VPWzo9lvUyeT5ZX2nozMbGKkHajeWuogMfqMiA8CjR2XAQRGJS7CDvKmTKUX+j6jFdbRUQmcmAzVE2CAWjFXMSgy7HJjKWfonwnqLS7cDDREKMMblxrEFd+OZQxlrTxKohRfE4KD0SBR+b8VFxBwrupk1GH4gekQlbRkKG3GK0rKtnNlpeFD52U84xOEhkKFB5hUrxu9NlsZVMpPUHxNeJ8QQzm6Xi7IxOPwV3VEAht1xP4vNlPldgjt7xwErvl3Tdhx8gJTZY/tQAsqs1FqV4xmjlEQk3QRATVMvmALGge8AkyDb8fZG65stwUj7cOmX0vAPchQXFYBChKxS1C8JYuKithKxQnVSJjwDvruKxRHD0JwWOgNVVfE8Sk6XdX1qxPfa8VRJ7Ir8UJNuo3RsRouGhie2/Ep8aKtYUXJ1C2z0TtqXbMurU3cHEUQ6nIegS8GT4USJU7bUSQLVPhCT9qklUSbLyAkiNeaokrSYbz2pExCYjLGAUTC5p7UqqTEzkMTlYmGUmGok4BIXycnKV7w9+IQBayimDAVxpzF9lFIEACBoJPzMEd+POqB9oJE5AiVFMIzwNEJ6VEltlKSGm9EJsVKKcPH67UoAGEEtJgfEZbSMRgG7fyUJSfEk8Nhtkqtix3uQzUke5UzbHxJA4R8apAkkLrSIXHBYbK65P9Bd3onnUGAIiYYl2R0KFT8qXdf2skGPHBZ0asU/xrOSWlpSYywxFEb8QSk2cu6rZWFlFPyz39gIN0eCMjX8m+JVh2DfalFNZrUTsGxLcyWLmiD+wbptUaMk5MSmWsrIB8dPoZKECJSMqUMgydxOYllMbpp3VyrZN7afNgIMnUjipOYDWCbpUDbkbDK7JHY2WdAZSltyEm3QpcviLcddBapASU+KIrca2QuZwSkRE5LcWYAiJETjANldSXsQmHmSIQCoDXt6xSCHUiJRtNlrFSfpAS8gucT5hmWJ598hJsFCkQeBECiAlBsMuOhLlrAZkZaPU/WT4jz6mxJCpgCXIrJemGVLZK4aZq9KKAKCAMGZUSgbkVlbDj+7sqmX5MMCtwXJ2skDon24nrNAiDUd2UX3onXQj6JmKOVuyAmEYJaX/d2YW1YmWR1pIiNOSqKAmGhRAVAtOUzTzkUNboDssQL9yAnKFKG5c5gBBKXH0ztZFc+uZuO1lS48RHHQjB+wdntyl2Xc7sauMLFJdIxpY5vCGIrEMYeYk4legVzUFgDa5dvMyiHWVjRsUmdctintROoZU15nUPSl6HGjAsHZcZY3mxQhqfV8gOcoaUWG5yfU3ZkhRprlSMRWc/qwcwduJSMSxz1yUcp2qfLXxdkuyR8ygKSKMSGUfKgC39r/OrC1UbsvssqdfMoC1Q75xPRnmZXWzX9lKR8xWFfNxQf8RgRI92SmLuzm9s50eAQAZPWyWQCGDs6irvUgViysW2s37o21QUijRReE1mtWA+y/y5GnFLutJRryCScFAU8FoeOhl6yhInIaboeKYa+Jf5+c7ITzOJgoLr5mcoETzK757zOOvbIWYTiSa/yTAtbCmRFPEVD8cqj05GPd1/mSU524xYIcPCsX4NWaN07KtOxYVpkwFQoHbiA2vkQgLmK41ullJ8W+TkBwxLbGYF/mVV6oh0nWaIR8WUA+2IXeCFxUfl2R1AYlELtbNupWL7I2PLunr10FWKBFRI0xEjR6YsKbKucBSU8hurMKVFxgdmXkqTrYLCkQCj6U8g55CR7Il4Vae0uupfUJFSlHpQblbLKTr5TAFEXhMZnXhUqh8Y+XVJSIuM4qh8WclgryUIL+lVYEXpMUI415z68Cgyp5QMHQd1KFC6SkLKYCiAMZOC9Eb8TZZ61lm3Cyvi/NCVEtXmsyo4XcvWkvicFH2Xcj0tSbXsWFyhSWiFzjJgNuFjs6Nn+jjJxM5FnrNqs3Xz6aKKpNw5uoB0XnXz5atvELiI3flPI/GdbQjvZE0VeSMBGS4+ScvCyQs2WhoaGSkoMXE4hZTQ4ylYqgbczm6dXFJbnHKpMrplMw8pRtgHoWdd5eK5IK3HSm3jjKejAVYZWNq3iIpGy4eBRx6WtlTulKg3F3JVXJBDQbyp5Cr2XxWRm29K62pkOAge1vlLSgWULOv40K5FXFP9s4pxa6qkhv7ZxUDJmWsFkgOPTxf42pFAr8MfUFcfVAnJ7KfltfAecGvwwpLflcNG6WJX6E/Lro3c28VLkcqPLoO5ys4ptXWwt01Wt4rNbqvRGpDtpujMCNcu0HKxtpHnEYJAphUITxhhtWihQrDpnja+pPfZYbVinyN8shE+BfwpVUNArev846erS3HE5Rhc8geUeI3nVL55h4haq2OJ5ziF1KDJdT3NAUzqpKjFDMr3M3URUL5GDO3oOKOLDigx6XceeOONFViz1kY2sW7zXZsBuJ6gXxAEyJAsVH1GkrviEKEBNMTM3NXeQXNXW/qQuP03ypIzfWVSZyq/FBvevMV6sO53NeWvtxC7AIEN0QzZqBJ8TQazWmcuLn+lA3O1cN7sbmjvzUawc9WxGiFIu0BrkbL+JavATBoEDSV6NyisYcTBekfq4ZHTU9iIFDqca1maG+oazS1zc0xRrVWjXWxI3Ubq2RGzjaRpo04a6AcXUTdWAY6wcBRcq/9XP0cFmsjpxXJ9dV0RbZiTAtYAzS+u/WwabsZmnpserQinr2s56zCpesrHhib1U46MZOoPVJqwu71eajlDQKXLKVCha6HfO83tqcFgcxqpbKTV6AllUETSe7AC3KVLpLCgNk92i26yARh8Umk4oPBJqq+3CvCPAwC0UruFN1PZiVrIUQr8q/m6peszkUrKGAGWySnFp9b2QvN77FQiwoEA44jZ1S3es6vlqRzqloCj1RHLCl5bTAEIuRSYAUWTa6AybbrRLily1aDFUuJtXBBfrbrelYAu1VhL60T8Dc6q61vgqKBEhLhKivXsvkUqwSWFZnQ0AdszIGtyl4q5RpElQ0baQ10zS2QEibGfbY6DCyJCuBWkRK6ZmQqugEo21dKTAd86IMpWaWuw4OB6hQBOVY03k8Bc7DMjKI2UMBTAq8yQlsM0Vks4d1C9HpStvJyDGFAbcncTB6Ecx+FCOnKppUZa1M8Z18t3oGr4VINvFOCnyglT4UmyUlTO5znwqJDyNdVPzBcluMDWjCbyujYGYeNbopb2d2Y71cLTJpE6F+c4w0BUoiUltUVwtH+pouJWxCx2ajD1Y5R0JbiQyF2nBRCAyKxS9AbsPFUEh62i77dHq23moFileN/ahS1QI7w5hBTpV18mysb3jkvBCd+ihblrjTkdzD4U2+2QIiyp6VPNP2lPXurnUNMthq60SpbJfr4dRceevLZC0z3baik6lNPXlsC0j0ix/okeSOINEXqsuk8hehKwDGr0Zxyas8gLKAkNy75oIlucuMtlEwmqT8ttjAoA5j6vYa7RLWTiZl2UhIgPOfcQ0oD8Ul9/sSgJbKVl+qnqh8LCYDtSVxNw6++vVsNrUlaT19SgNZo3MiTRSy1+IffduxIU794lV+82Z4Pz1idFaEi4BPfyrpNlpZe+7upHTn3goGg9wxffgRrx1sUmCEA7sAcJguNJ9bZNblfqTXA6HZ1s2pcRUhB3CEl2s4xhN1wN/khKEe0UZcyv3NtDQtWzqCkFGUkGPmvyh2VgqObAH1BM1cuVLMWro6rBfWsic0KgOx00a+erpQhpvIAtwdpTX5T/olQTFYhkSQDtgsf0SpKlk+3WUjJvJAzvVd+4+hu1lhyT/9P4vQ1fvaZpL091Fb5SoeGokd89ftM/uwd+W365q8B5GrLHSqm8q65sm2VAeW4b989jVWRVAcVgaxA9AB8PmFTwM6FUVO9QYNPpsq9zRDt1SI+0ux59au2L09A+yPhFV0M2O4wpB+wKoHhPqg3dA8PykPjVWNKhyyLFXUO+t+ViB3+qXQERi77FUB4+d9oERIGQ9JBsFQoAPW1sxc6B3chr2uZHc3D+Kh6rVpwZdt0DPrUXgeHymPB0D9u9le3UgEn7zoF1SfYLOypUHq5JCuaWJyoO+KUg2+ymlYdlgQGv5Q/W9iVXcN3CI9Mtanr4cSmwHzhEIMpewbf4+zDA7TBNdYaOzvG0yvNHg3ZEMPqHdlzrLQ0qshMmGhDodHYxH1qhX682rZQ45Xw54qGfhumUihMMCUkHlYC3EhUmrI2+G8dTdNAkxq4WvHeNfWsJcAlkMxTWAeWkxskCoM3NotuHZQ3gcNAq9LZfmsDSQYqWI0uTRNLmoUmVhKquT4nafR0xXnRbFBPJ6/YkBIVlMo1V+sTsbxH1G1PZUB1QMMrn0XcA1V+ihsPFq2Xg3y9xqsMFJfn2pFe/3KAxLUbrDbH2gh4A/EpgOWz1tzU007oNTkB4CR0+5njcaU2VDTTSjBFTIiaVgmpcUdA9bDWDVX7KZMU702KJkkkGlx10PrbH21XJmwV8jNM83OTPU675lMhQVfrkpO0izhzSs9MO3kgVEpshtJVXzTMpAhj2UhnqdoW27MnJxWbttGddHcTY6ChkCqqoglb05V0ZntRBItod00zdXPva3OnM5Ulzw+w6DQZk2zjvTm5sjtuYPCD7a9w8lLqPIshjiW9YrVzQ5tvXTjTE+57Pfh24n9789wm52c+ZL1oCcN95/FZ+Zo7fmC92yWzZRHs3BinNF5/gVeaEGzzZ122ugIuZYXXHatC29QBst6pAK2zSjSBUqYj09mYZ62G1oOEHMrbuFvxd9m2eAX1DF2CZhgFtkpWpN/GbZm6MisJj5DDotOno0JG3bXaQKEc3VUm38FpmDp+i6/tRfE4bLrKagOfbs3Ir6KRgxEtM2LONXaDhtj9NcvooqVGGlNb/dS1iu9PZwSVlzTyjIgFpwKcFF1FSyIGbb6LvGhc+LWDVZW/s+tEtAJAptD09Uk9iYtQNs3KXKz+u9qFy/hzwP2rNR2UBoMYF1VFU6NB4KWTWEpXtaz6I+hZlDtP4LGes14C6L/JgkYKDzs3RPnLsVgBCDzIRmnYXwFOplvL18zfoDUn35V6ouqkRu1ui0i1gBkIJEeT2i0HLKV+DYwB1pDV4r8MwjCPZix8OVW0yEHbfeNFnIbKRADQPNaRQVoMHWr3KnY5jgQM4KXqujbfUDKy0/q4mEeiKlpV/kg83BP2ufr+d53UVVAc+rKk50yuSDat7ipcZlcGBqA+tL7dGplfywCWBERNQRejvRrDajVjpnxY7KKOkVdeOBgwyOu33icMzd+APYcdwYjW7dhOBXaRW92BFsl74Dq74spX1LicoWmvJfu61AyAzo+svQevJtLyYLB6w8/fTXUHn12CjBmzIl3PU2t1CZtm8+BpsLnVzQFpkCBcc0isJx7em89GK73bb3hKJ78e+cMSEYh9jco3pNZSMX8Naj61YMrdNNKK1jgdCDikZDJdzvTH2TQy4QXJIX5COm4Ax9gn4kK6ZI3TU22VWG9cBa7+8aAVctnEtaVrtg8faivZ8zgDAgEwEYYPiCr39v2khQfGnzT6kBBLX2/BFZHVGD43eqRmcrmM19qL5szY0VKprenC+Ezdo13LtNmMCscxpRSQs4ZKbS7cZy2c7x6PVHXWc1oxkfSztXXuLgDQZsMcv61bB1Lpd/dRvLsI39D3dFYTXdJps6SDQQ68DlCN6WnIDAdwZl/yN5nEgjVts+ordWDXdd9JByAR0PVsP1AGmpqiZ5QErdco6mpjGwBhPsG5fiwZ0wCXgJBl51BEpqsBORrkP2A80+CY1EsCIiIT7knNMqacJjIC/721Z+2TW1Z73qwvPTY1RP6kCVH2ULU0/BEX7v2mm2lp04iPXLwOFyNap03Sunu9co2YJ6Xpfd64sXZDK2pSpA4gPA3MzVgg8dg8CPJnfq1D98M/fK6SXqHRwsE8bx+ZcOzOlZyAYC1QdUUcDyM2ndG2wfhsAZ9URZiI7x0zSyW4q6h9uz2kcHl82DlefRIVC2MVHT1mW63M0dVGNx65+BykC+Odz9zZj5Y1+eTtS3EI/NjwILdHHN6+BP8a9defc2nAiKVeox9God56PaHQkXtmcfkf52VFnDRe71zKrWXva+QTRwfZ8sKhQnCTnzXZA9r6beuO/Y3VOz/VZPpBN5PVqbykcrMWFqPIo1I4+z1XeOXDqmkddm3xPeuisdkyws0nRBTNTTuI2xSvDRBj7ZDhat07VpFVf7ZDtGoM9Jq6ZsHeC1KlyC8kddsHFy8SlyClXUP3GuVZZ/g2ocWClnexJGg1GwdO7XmXIZ6U1pEchNxnUp+/iA9+0XPsqe9qXHmxmeB0IReTsc9B0GeI8+N798nm1I+ec0Ps9zhQR30ED19D53z7ni0+tQ0AicR+d+6/j6YfP5G13PewhBGpHPA6VjV5+h2ikXOKGHTtWocx2ewt4RStyy7RWOftOUXlMy23YGOdiArNGtqJl9Q2eycqXz48Z8kAaVwumGDh2l18E6rEaNbTtOKlyB9aailbCtdSlyHywXcqX7jcl2JGYDCOlbideq+tPwxUvmecWgBlvu5e27WrjJvpxnS6dlP+j1EpWw/jxU/Dm2VL1/NLZBvlCCHL2Qtiks+NQTuXg6z7S+wYVK3+FG24pj71te/L9FqrYpxreE4bLkt9S21+zO4VgNVqvrihtwoCcevL+FN21yvZYg83vwZTZm8Xrlv2uxhDN6xxY98dWibH3Njmyo8Z6OPtgzjpvWBbcdKIPHUF8W3eeTUCUNYjTNc+vdNsSNYZ75+yqmrjYpEO3eJyy3ubHd9ueWx5zgY3rLHnmm3eIFtx3ugtVv37SlDbYHIAUbviYr+D1eeN0e7u8ImikMskb3tKVSj/q4No071WVDnVlfTTUIR0Ier0epj59/buj3J9SHd7jAdZdRX2jzdoqlxoWd3fonPtPvCp0IV466rbeIksDztavqOUL3RJl3d12U1CEFCcVh7Du8A+SW4rHnDVxu7hpb278BI/F7HJMYRLthr7e0f4P7d34kRrz8y1ctliWQCWdHkWhbq3rsr7RmLamXbtr4K77RBjCXYcwBcbviWgV2IJ/V489YAqhnMp0zVhcCUW65siJXYyoGqfx2DRu3U/dec+JIWxu5ZvM+ygBrlddu9j7e+UJ5AodwU7EZ29lVxWghRIxzyqI2X5xfJe9pgAJI8+/FgM3nxdi7tQ4Ju3SutCK1j2s83MBPQV6Od5+OotW/jx0kZwBzPp42q2OrTtxkbxt59MhWX2tvSturZWsvFtElW8fxc6FkbnF5tk6+iOhqySM1lLzoWDdArX7xXt0sZRSW3Srr8X3OIl6BrmH37OhasLqu3dNf3VtFMtwB2mHpuhv3U3PRx+yjzf6bxeodxO/Zv7q97+B1Pdm8A/E1a3bmud2epceNuRbposW948sdTv7d/bp84Y+6qaMe3P7m1juOCpHvmqlzUNdxKYulX37NrUKszO5Vly/visROk5NunH8PvUTPab+2UJ72bWeHQR5ZJB83drTsLa2/D4KutMVDTuu5yD/dLMP+jDLuyB1WVOK9ahmP4xhMfbl2NMf51Ie6h3oPw+dH4Tkg2A3hfM/93DP+g9BGaruLQ5OanHLe63oWUkHDFfF++xZ6APeG+zyJNYMzcqHZHwDuX7m2tMyczmf39TgCMV+WWX5S1TRg/uy271Xne7mytaZvvmM97ebH3ufd+2y+PeAgYATr4qXE+BaLdU09RS0p73G6KOwB0Tm9+EZ6tTp1fsq4IVG0kH+WgP7fKQfaFBXkhE0xg+ane+KlNJj03bQ5HPUo6POxX6/kA7J+t21P8FGS3z8BVkzqbYT8bLE6bHM6oHzPx0Op+I9ctmf11s/cAb5Tk/TtCY+ldd/5SbJsM3jeLo7+9O+zAA9+22VTLMyk2yjTP0m3ElHCYyM/7H298h/Gz0a5kwd6v5mmDv9CQIyd4xQjpeWR3/c4X78UmoHfPHR3hzSd+FtXrILq76MbM4BambCOisXl1yBgmX2/0pnDMyC4LZXOXRBDIi5fWz/nBBQmCrooLJKnGqkyvcfzqKLT2FnD2p/OE5PE7DEqOpC58um+uBycaRLNaKIuUTJRrqklCjs7iMUWgSDTEDvOM6YMIAbcrom4zl0pJ6m7ISICeoru2z7OVkOpzjOL6n+o4yy3Gq5RKIAXTIW8rTkkKca4qtbZHWynvAEP0s7DjrNOwPhHTWC5Ot7QJuqNGcTG6Zik36qysch56SCRHs9QxaaHloyvOXFM4zZKN3D+4h8iXpswL+VdMCx/WActuwWB6Jl1oqKaTAipLULzP64uWUTnZDgGGKmZa7SkzooZsm0enUzM+eQP7ZmWGtHA5y++VMaq4cz3p56yWSQvb5b0BuPSqPAwvkUziW8jG/yc+Z9ndpfc8DB96dQQpgAhKKdPqkJyKHzFc6RISslV6gBNFNfQfeKfBtprkYbiT5w0ZWsMoS+zTnqZjKa7MUF1BjlJore0ASHH42skAlhaZyqQaD5xamdDQqY+NFOQoSi9Lq842sVQQhZkwQwZ0Hras3lD4Tqu3g979uReot7pOj3it4ceO/gEj7B1wTt7ruM/m0Fb0NgdHgMedkF9bzOwEIbSsissHmzhCm7MRJC6CtJD7DEidDwSmuK2tgEM8EWK050yVmvhonU01gnwEBNeAIopKTCiIqIa4vItqVWPlFg5f+EBvVZOsg4IhryStuleD32pIXEAiuatKczcBm2u4p6Uj/uNRQBebM3zn+9bgu6uOZ3tWIzy4tofBZUwnjspCBVtkVL0hfJilL6mgdlcFwQtbH34qG/jJCJkBcEN8xAG29oOwiaBgorxq+cclIEgsj5vha0Sv9o2KMmX9knaL2oSpjhPe2AbVBO+JjorZrSHVHv4oB03hmYS2LobFoK2n/g/Q3BBjqY7jE92nBJ1WA9ErSBhKkv7DO6ogWZzKGY1ClYEBbHAeROSlSsaHIwK0s2Yh2rFqGG3QAvnsSF0HoTDrscOPinISqWYckrJmznHsyhhlnNX6+sb3MqHk8ucCkZ20cwKIFh6WJjmpEwTdErQVKbRh6YVhUgb4iYBHvnrzxhlSr2ps+dTCSG20vGqabh8qwt2EukDPpJzeh67H1DP2O1B4rdhb/OuGE4KYRfx9eh9uYzxhrfBMbPsevthDsy+tm2wphKcrKoO2dVJxrdKrNM/bgM47I+FBI+Rm3gBqBAezIdmAdiZrNBwxIHLWm2gm+TYBgNDdTv6NFiGHDE2wtn6cWIHFIHMMogH3aj6BAdjxDm/cO2ZsBcEAWxr6UBr+KMmUAUjYTGR3O8xQBIcmCY/0oFFAFBIpsiob36IAdeJM67+toTNGiGoSK0OCoYKF6hWNDWochJYvO5jyp3rf7Ty5opd7o6IygQFw0i3M9Y/MUgX+xU27OvEyVhEKO8x4WjZKczSRVvH343kfgXJroiJiijr8KnGm2wYsmVlxQGUpkfeCqcpriLzwhjuO4pxaR9L8QuhIakqqZW2QSmHJA+Wplbs8KnkkC+IPVM9a9UOEcMrc8mViNScatoRApuKBcgv6mIgNJFJuKULMA54YcQFDrwGcDp6LsceBjo7VMiGuLqxKOCnMD4hAHHQYkqv3E34vKr1OpZQO3oa5GAqKin9y8ewEGKIaRSAjAKPhPvCYpHcR2o+FK6yKjQbKa2ELeStat0hn7/0YDG0HvSe4VKaLWM5E2KiB6ggjrx27VvWH6saOrhHWs9IYryWcEKsPCVqG0fdiUq1ovyYbR9UKz4ChtnnuFFMNLofDcqegdsRQMHqpIrSmG0bFSvRj7A57S0GpqlrgG3qt2Hh8GysGEWheSN4yjBh2Lz7S0ZinirvS//i9ySUw6qi4aOMMa4rXy0yueT1hGLKSL0cXjK2G0yk3rt4wxlesTE+hebjKGehC3i6E6EGZnChiq9IbTGkxfijeLc0tMedbhEU2pmGOhuVFsjHKDkToQL63Ni3Sv+2AdEBlCM6gnwMOjoahqbqkoMfZrSBiq8w9IIbIzHbUpsj0gVylIWtIi0RMZxSJ0YselSpUe4vlQphKHEgKbqGLCoFT6ChJnq5+2AeGw4Gk6gsZsxl1uOG+OwxHEy8xs6lZHKhROLaoberVDTH26a1moI4sZsXKH3Bz0hlSux3buza3QASDhFIM+VJuozU7gagFdkrTEPDiM54dMBS+1NmKquRUIdYJxUVlFXxmxhlsrHeURJuhG5sf4Vm7mMZQlCGUG1NlvSMqzcTt4eUkon7HWKpMWDT2QFcfUpfUm8s+FIRklBtqIirqj3H1K+ih7TSxs6jzqSm6PG5HEsPwUUCs0T0aQYxOPloVYkawbP4FXGSTApHPsC0UVQCAKYQPGAy1HpyCbxl1tbIRKi3Ck4QoJHB3xsesFHJoMA5QhEpuC/XFJoPOROrYwBRvgeKoOOdekOKCRx3g243+LmmJFRil3gqG0WevnChJKVygqFD0j6nCjq+MDgxQMOcKKi7ghafobLEai4tDoM+kdrEJPmgxkPZS4uftPaLiEEcjY4+BVua6UUZrhQ5YCpmpRRBC+EcAaByrrPxqiCpljj7AsJYaLiBERLPmaOULoY3TJG5YWEo4Ri7CFROSKOtlHpOicn6EOhaicY7gxmic8FbmHbhChqS+ifv7RCFbgO6GOpiRY53e/ofioacisvC6iJtiQr5DwFwMqGzsexkRJFSxQYlHJa2kruS7xPicwyA+BlC6GzstFn2as0P0bYmXWUUhFRSBy9q94DEsvCmFnE7PJWbPhQCRJZqhKhhwrrR/HAdSkiOSVU61+iUYCGVm9LppqJR7Gmj4XU8gYlErgtujkk+ReXiUq8MXfqD4+uJSnGY8Ol1hQklKr3Gj6N0rUeFg18sZkuKTReqn9zMOC3G5GTWAnjj6mA7ZqZFBCCdiAqaqpkSZpkM+pmcoMBakctSbG3Brh5qRu2vqaEimXtShlMshoTxlRxKt0JQR2YtJEM8mNu0YBs5ycAk+sWRotwORT3IBxZGZyZxoeUEUcEbe6KYXDosWVBhmHSJ93EPZeqWrPxo1G9EbyYra3oXXI5KVBuAyTOn6hFLoGs3OnEvAwVjimxa0iQxTzJhSEuKnO/6v4zKm8tN7T8aP0r6EB29qhJ7/qkSedYMRm2LnH/yF4gHbomnwfRDjKp4aAoIx0ZP0Hb2mLF2GIS+NpqYVyfKX8H+BCoZdGYhiEnjpfe2WlTQOR3jBfxa2WrCilXsavlXwVOYietQM++UpvGe8OIWz7P87EYpIEyX9qnQcelFA9jEOIJhSmUUSlPKnrYwMXQlGMIjEuFkSnCdziza5vuzL6ai4nGakpuQHCEYJ0LuBzm+tfBn70Jx1EPY+s8tNGmKCAku/q+WAaXoDiAVyZZziulFANafhkgmozRpNYEGnDGdcWWkCyhSYUj+etHpRQpAeiu0a4pGqU6x8cSKUUwCJBKcEa1Cv8VwlRK1pmRRIiZaWJRiOeBulaVhi4qqrth1SurT7OG4h5RZ27zAm4kJFrEPa0c3qZwq8uDEQxyZhmCcrJXJuypiHIJ3utPoukqmtGmXgWKpqaIJAaeeJEgoCbO4CskCVyEiRMCaLZeORFGZawsurv+q6yaoXWnW2GqVXwNB8tmBHKhDSX+z6KFHPpp24qQnxbRk1sUF47W1tPbHKh61L9T6KhIiS6ISSBkE56qAkgQEMAqOjBndC9IddxA0dUT6IYZxWBakFG9LgpG0SW0boym0cmh1T3R+BDdQ4RHzGRJyKDPApH+wxNpipVUGvNzQdU5jg1pAibkUVK6qQfEAkZssco8pAOIAWb6mWh8FZz/BpiHJJXRDamvz8cE/M9rwKwOqzH9JKfJApia3ocVRwiFmZB7RRqTAQnXKpgCdZuJL0pm74WDLNFHjKnGVsKVCXmUV5delkGexeZ94HPbXK7Zikn3YumahzSMXmR7LDqaYfEldu44UYiO0LsT4mI0yMQo5eZArr/IfUiwW4nGSWyRjGvWMcT4lxmM6ogzsaOWYOGVZuzGJnlZUcXOr5JdiRt7NZlia+qreHWdTFyaRibcHgmR/P1n4BXXrCy/xEKHIz+O+3FIHsap9MpmE4AKcka9hPytGSVJQgOWmmywTvuH8a5jihHdat7NrGSEQUXioCuzKaLhCU9gU7SAR0eF6rIqeOnmr/p5Qq+6/pGqQBnl4AkQ3qvpwkdAmt6JoryHiR36bKyRcBIFwmZZQXOoCX2IOdn5tR4OdGnLaX3jDRA53EnDnVssXMQm40mWe9knmQkWebchokZ+l8h8Ce3TkUZabSpt0Dvl2GQ5ZOdXTxO6bHsE1UHdH+q05X3kTkhhlOUebsCH2Vf5QJoYnjnneX6ZaJVg7oiTmg5kvA6LA56Odn5oEFOX+R05f/ELni5yOUzzy5T6qTns5xYpzmgW32ZeawJq9Kzbti4uSYyS5ZjMLlG55Agrl3C0LEVyM5MuaGp65oaRLmAWYCSeoQJXOW+la5EFjrkFcaBA8km5mYmmI05DufNyLssORbkVM+YiHmy5MYj7kG5quZjmX+muTzkfpfOQTnfp2TCIy+5VLLUwZ59LFnnm5keWnkNpNudCyssGeXHkvpruV9mJ5P2Su4Xe36RqLW5huTYLCaitmzmeMConnmhq9eRHmd5IogWmB5ZeYGIV5OOe+nV5d/rXlEUSQCvIB5jeZoJNiDearn30ULPbmK599H2Ld5rYmvkx5GOU7l2aLuQnkTy2ufjn/ZAuerT6Z9qOdQWpJ9qD6ZOIoslo08SmhX4iiX7IrQb2sPMT5H8+GOHR0gz4T+5H8XlsjyXhrzrdLKwCAi9gvscfj2o4s9vHHy/5YNFvbhucKag7PBU/M+yUhiYsdSgsLPJXyQOfZOxyrA4vk67/SmBdrT3OS6gDwkF0Vi8Iw8FMMVq4RupuQViUEetoIEyDBZ+RNWklmDzG8IWtFqpkU/M9LNGpFNsL4c2/C/FbWalOQW68b1luxhc2/DdxvWujKZayFG1OnpCUeLLmGxyP2vGmZivDB4pV0I8NQXo0k+j8k8J4rFyLDaDAPIYu86xGuyw6lDEKbb85Pvnqoh/btvwbxEeq9zx2APO8zba2YZ+4w87Hqdo0MXkqPzLURheIDnWqwM+GrUO6tIxWFz4ToZxSLqcjzfsqVnFJi4UAl5YvUDsqhxWJQrunnayzlqz4z2PrNkUukXNOOScmBRcfI4CSTEgqJ0CvtvzEK2RYXQ4CRtCOzNF4fDTxfsRlrta0BZPDdBM62Re1rlFH/FOwHq9qjS7wOmcWAYPSkQZ2466hoNkXO6UAi6QBqSxRdxTUPWsEJLF7cpsWe++OvarypUuYRjVMWOo5J+U5vFno/qMUiMWQ0evM0XFYU1KJTEq2Rejz48oMu9FY6MLk8U3cixQUUIKoBdmaN2X6gwaAeakkgryGl+WgR2MsenFICSUAtMLrsDsrsJk53KssH56CgMwColqUUYU58qJflISqXhouz48MUoAx2GgMjgKhZZFsUZCZADkNS/EODD9op0uns1Sp0zGl0aHYX+a7DlcUhYbJk5cku3E/W5jFyVTaBptvqAyzyZLzOZWJeKW5+R1HgI+23lB3RQCRJkxbb6LlCKUWszSPRQQR8pbJw7GkghVZbUktB5brx6iVKUQchJedBRs+PM7rbUGWvAbv8zuqLQdWYDC/mxAxLAPRoE5vIW58exttFo+lOAkVIIKHVlZzv8JxS4LV6qmk8URyOtpizLcTxS9aH6R2hvFPFIZoDbT4MIaLm7kRHniadaexRmwr6c0jTycR2+sWVk8pZQeZbYbBuxTaCLxVWXum7FHoJJ+B5vtSAlDJXGX7ukpU2WncIit7mZMgJf+j46Y0kcULK+rNFo4sXEd6WPAc+h0yABFxUA6zlgZUdSelQ1suV+UT3IHbRaUCgnZV0zYbVpW8h0SuWR0k+kC62lDpiQpMaMBvKXM8tNtDJG5d2Y3bx2SBlNThsueWZ6R27/DQqc0I+gPEkyH3lTJ3yL1kq6vlFguELZQivDWUAVKyh7Y1BoBRwZTm7UAJyvljsrlpWihxUdQQGppVzzKGehU2l3yqmn4zylK8mWbeMUJR6VG05tgj4rl16SpbKEVhnuVnsOZijygljFbmV7EhAhaUHkNdqZw7i05e8ZcFfFSkSSKEevu7jhfHhMShOqwAux6y9ojQbUSMiLwwP6aBAKk4WFrFibe5wZUbYWCtxQsE7mEWXsXVlOZm7CrmFZee5sW8FmQKVlM9gSaqeGQj+6gaTxRtR9lL2J5KJl4qn1rXga4VyXFUZMjXZE2hYVSZtWNdirSOZfHuLqeVznLhXCV7ft+AYc4ZYuU8V2Ye6VPc7FYJUpV95aJV0CIpc5ZSGIVKAXO6IWFS58JxFTQYoupFqOWh0RNCi5DlIpSNSP5kdMEVDUlnJJob2ygPBXEqdYSfZT28oZEheSK/syhR08FdByZeTWMfQ4CEVJJX3O7WtFXFWDnk05DqNVFbzsRVoieV90f+fb6XgXfO/zmmsdJA5CUgVedBLiEBU0HqyTZddQku/lhzSAlFhcyn2ou9OJUBaMUrAXaqtxeLJiZ91S/FPFh0fOH3V+3E8WeCWnufnnsQZelS3uR/PFIXFFrL27syvPJsWN0+/ufn3YXJUjT7ukDjInulerJozo1MBqAUoczDDjXJyU1P4wEG8DmkwjFsNd2xk1SNPzyZyKXqqppJA+aeblizmqPme50YgAb65ZNShwu8mqYDFI18LBUy0SN8ejUqivNfe6bVXfDgbuy6Ju/mb8RpZX54+UxaKJqFB+nl6fVwjELXvsL1ZXxC1ZLFg73VKQCTKqyP9Pi6MmRpfoRbFkDu4o4GMNOFa/5dwujGAiIZJoE2m7pN+qzWeHJA6qqesrTTmm9NbNboBLNGTAYeGJKcz6MBcj+6Z0wmicIB6xPk7rwGGjBYVBB3ODgwKMDzlRIou1FDrLkMgzIjUSilNHUKhUQWTVU6E36nfzNINlaEbkMI3F1WRF8JsqLD8+OoczFZYwmAxJRIVfdg11VMklUUc3df7BIWK2kKY4yaNJPqqsxOOKJ20/CYdD+CyNl8HPSY9ftrl1fUIMwe2oUaYycKrZgeDOmNNe/QmBTtjabBSNgvIZ1h9qHcKJ80tCFpOWlVAyljCa4brI6mewnkigyiVvYZJ1xkpPq1CRXhoy/coxtfrW0ATEDTy2AptPgEmXwYyoHlSLh3JfBM1sNqnSvLjjI3KApobIc8I9b7HyeSNEXXWs99t7miCCjCnIjKrpR3Q11IzPSaScNdUXzTGsjhmY4yRtNvrbCrdTA2HRZZRkzL14wXfKXMYsuQyZMXpd5T3cRdeezTGYNLQ5fBg3IDZUWudRFJvW4nuKKP0RSKdYBqATC+rZiP2vDpqh6ugCzp6P0q2JUc7JQ0y08GjBFwVaKQpAKtiKIr8afUmbJ4w6qN4rkbESyIsAG1ax1JsyvCjXByIN03jAEz4eUhouw6qQtckqwuO6msF61Lnuur55AxB5TDaXfFWxa1yjgUUe0rzJX452BRQTaq1YSoqWWRGgiyxVOOrGcW1ZLLLszX0ZxQ0kVMPlAYpLFZxKU2v24FT+oq8LvNdwX82RddRe8csE1wFFySmoVNBsru00OcOzJnU9N49u3RF8UTRD6IstnObwVNxBmgS2MpxbtYDWFTDQbtyQxYGoLNzhSgZpaiTawT++KTbToLNaFrQYjc/gWeRYB8TcAJukbHOMWNVLvP7QlFxRjBJrW2UMZISetgRFKgsSUT3XFGrdOgHZQr9IVZ7llDJs2c0xOTSVCZ1zYUXXWAVLblKAq8T9qXM2Cj83asD1pyBWhfzNVZsc4pbvU5ct7PB6CFzToiy3s6JXloEMZaj82Fsq2jB74tQNFJUqhjZUISQBDZTWV0ttjX+QyFjZDdwrWrLcuKn+E1vmXZNFzDVa/sGZikxWlC3C+pC1ngrQWkmrdbAokm2HEZlr0JxbM3y2pFuK1x8AZaoCmVOXKIIKVnHD2rF5BvF5rGSCtbNI6y25SnHZNakvSaHYS2VjpxerZT95C1efP1LyeH9NCxBFLlU0KMteqvS09Y1ZdCwEt1LZ63+tVLUwWZyrPqS3naiVrQqotzPIRZKA1hZmJyMBIii5RKYeR6y3ujlX8wmazLXBaathTC2wqWJlaCxTsWzPpVCUQtYqEJm3apmL6l7FYTgq84rbCzemSjGdXuyFygepyUMdSywh1o5k0YEm7smq1xVJvIiyiCOSjXZYKFqW22NMIVa3xC1qTXfJnKebXAZvhObqAojtSLm3YPYhbjuqxynlY1w0uABjMYpt/bd62sxqwKm0xtUChm0XtWLerS3uCGW81BSlYfabsaFTDva4e9qOInFR2UEUzsl8DkPFe89FZiFXVdTHs2WsZNSYX4sK1U/lpCfzDZzlc6NQrQtNxPAwFI1HNKU3W2kxNzWVyfzD8w357Mh5Rq59eljmfZw+e7nuOY+fznhcTZH0kpCwavmxo0uGb4EC0XrGJBJ2F8SRxG5qZEBzKh1glMEg0PiOWkGRwWldQWCpmd5QB6ZOZvyCl4mcUL482cHJSmRZgKOVTscItFGMy9ERmRXWyrqEKcuXJZmRX0tEckrv8llg0kURWGv+yvWK7YhquRkxd6xcxUAd1yp+4XOyKfMiGlpTZJgMAQwghuEdYWsdcrKpHX6HlAHS2MOutgGii+henQyK3oVVRywBtJY2OdDQEaWbsDclAFwiCdrAzBCLoR+y/OXnDkpgxNBhFQ8aJmmFG88jCedLIS9IQdLld4wsnL2ZJgfuzQtDnA5HX2Eibpq3hBAbVIk8p7EdxChAcgWyNdhkaonfMYVbAwacIAeJwLsp7D567JjrAkbTdJ0fV0uc0+KEk0JO4rYqt0DkfCwJ+UXa1KshxjEuwrK1dsqHjq2NGazlcR2EZ3ytEdHUxwZm2ufGNdLPIOpQBwOqgkt4ILC93cqI7j9I9U0UR/TEGB/j57xJw7FOUvASjFV0qcSMhmQfcOEW/xdtkvAuwq0pkcoAuB31CsRudSQED7fd8MQ5HPVD+t6zg5Loe4r0Rl9Odo8ZTadr4s0VnET0+eXEeMSI80ke1WHdq/C0npOjMiO5EZMoYjTre6dEDRrhcmo6WDdt0iYl/G9ll5xG1p2X8acKS7OeJRMGyUdguc9IuJ2v2yfD12cNpkbxwjuT4X11ddocqCF6ppkQfJ690LS+puR2QiT3Qt+7t5FFOAdMIx1cpkUDKDd/RkcnvBeNIN27S5rtSgy003RtgORcsNjwG0acd8m80qPaGHjBAKV9yFh9PfITfJExG927OtPrRn0dRHeAka526NRQ0At4PuQ8hh3sfl8u8TKa0YZdrk7XkwNeG/aiahbDDKCAPzO+pF9O2YM51yKDlJoFYcVHGDT47jHJoBUhbnGBNMNrB/HW0tFD33Xi84c/E18elHGB+M2Krx0sURpRP3KyCkR7riUcRBC4Xx7IhzzL9pnI8kHdbFHEQfM3MST6oh4/WTg+83oXIUFMcYGUK2ecmt0IGSF/XMAwRP4pvxH9QPGsW8dzHM/1MWBUeNlyUO/SNryNvHe3JZlFkNUrtsp/bhw0uF/eLJSB74K/S/93QtbSmRi7MQYX9RNrD39GJhRf1bVAHpPmVGv/fS5i54mdEAZWZlHERftbkVYzr9AHBZSqZCjr/3rCkvQ9R9+PfXoJHR4mWLJ0lrUBiTWipkeLIMGqYLA30hsFBAOu8jMtZHIt6LrKos81kV5VSu9EMDqw9vkWZTV9wnMMni+ZaqX24aGyVdYKunwtP5JAI4cy5/G1qY7jR8Sg0YO4kyybLFmDcwXimHRrGlbi+90UbxVPOn3sU6mITdTs6GW+/XBF5tKpIP5+x1gktlW4sVj+EwSB9MEOo6y0Z9SGD8hEgycagfCLyDOMfTfkwCDFEkOhZxPtbJeq6Q0wpbeAsn36a474KwPTNlyi4MxSTXlKo6DtVCybYOuQWUMOC5VdMyeDtVCJqRFH1LIOGyB1F3QhqVjIM70K3Q2UL2DJPnSEDDxlDSGh0LjAMPnygzuLHyG3QyKYSDUDkR6Y9MnEyGSEfElXyhSv/RFzcVQoLBRDMJA3sTQO8wyryD9g1S5bdDKnJEFt9R2EdFJAxEgSZt9vrJcOSUrzEP3SUVSuSLw6v/QeQgQew48JfUE/ZDShOk+WLhqhcRDQ49KtVLkF4DptJDLLgNrLlQX9QIvCIQovNNcP4qCcT0rl+3yhf378/4p/Q1lkA8VjYjuguOGQDwzv+IIKuDpwPZmVnP+IB6prLSO68IIz+Lg5qVJAMc0fEv4K9mhw5XzvRhifWl4DKMrFLtM7ingOB2CxoYk0M6lBP1qMezKP2ZMdA4kDsqz8YzJL9guelZCymEo8Mu0qGqKOIM3fV8CzW/4lhI9GggMTykBVUrwwKu61LhzQSuHDzrkwJml/xVScoUkPXiB4lVKhSsg9sELc0EpNZv+X4QoIOj2ArINNpEcg6OpsTzqhxHuVUjwofOmZK6Myea3Os7Qu4bD0p32UsnQEZOpoxCJpj2hMUymjFnUdb+eN4lRqzWQup/J4STFkrLfxxlNyPXcnGe4oEs0o+kVWKz/CErgmyzLB7ocuWoYmP06ljFRss/gp0V3aN9qxZqR9SnFp+CvwkKCJx6mfgRiUI4/vx2qhOKKMRyB9P3Cw8NY4lKLjjKgTJUjIdikrwsVbP+JTWCOjUZE2BI206zx4utiMuu9KpkrcjZhIuOm0NFt0O18BGWNa5K/w7XxxaAxf/2T5zDFa6SUEnvcMESG2rKp9elwx3SGDKFs+EnD3XDmMR88w/LSGDoDVriY9z7OAGF0Z0jLnoOULtfxOcAw6AqGDcIswZ7DQPDWWCAuDJ0b6DKtDSFyMSdgMNE2awx0Kpk3Q35qGDHE7CVmAfPGYMcTA1VjJDDHQlKbeejKsVG0TKOik7TNgNEKbSTgMsT6dD3yopNe+79lKaC1gk0zrNBsCrp7STKfCAGws4Y2TKs9qasSqDO1oqhzYBKRSZPLaZsWRNPOnkoX2kh1wpZNuCrnvUmfU7kz/bRRfgU5O46uPZfy310kzYXLJs9e5PXpuPbozmj9Qv7DQxjuBHKWTv1A1mO44vpZPWtnXdmbhDmyjCqCDorTs5J2U7BsnYCxAZhIj9LLZvyIuBVp11jDTzphPeRmOLy6tWfbN5HJOQuibJtTmOK67lxgg1KYcW3lK6w0DNtlYoWsLvTZH/5d2iEZaeSQOkVADdaVA6w94aiSqxaegwiPaC+itYUY9y4GVSRu11Kok3UwkCTbwcBkd2onjm/FEmXKVg5ir4M3iT+I0Fm0wnH0hxEtylmWcRmtOy8aTiFpNB1/bdNWK2YpikH9R2lYpg0H01fQpZWKIbKn9OSt2U3kYtX72J62rizyeTrsLVLTWJlTNPAJhOOM7X2nfafT1TEY0T11yTI3y5NMbQkX11cCrq/TsiAKS21OTQaaCltJgzteKzctM0zo6DOaW4MyeFlAXBM12ORn03YIgFWA59F/nn3fevASl7ISfgnBIcZNViD22scraOYYCQ3GayKzd8jQocB34mGXOGNCh8x5yfZHo3gmvTuZLbBkVOnq0ys5rNyN2NCmgYyykY8noDF2jlNrOt4Jp8Z7SNFkawq+5kSpIv06evGV9molG9aOU13f5JnsD1pVQhz0eBBFBzWlk5IsU0ReCbQ8tkl2wv6tvHxx7UERurPYcQ9rzRCZP2ujwcDJBu8LqT72kopo+1cg9YpyCvl6Ats4pQxpQGqLil46Uosk0GyT7SlxF5wEsym3ESb2TvnAWe+en1Gggs9n285f2XAkA5Q83JJtzmtnZSS4hLd1UK+c80+5FAG7FGTteK8/xRrz11kAP4gS89vMlUe896bTCAJpPMR85tr/SLUp874qwtJVL/hU01LeMH8Ud87rTnzKs09S/4KvK/MnzLsjdS52M1rfN/kVTjha1QhtE/N/GSsrbZ9GXNBjjukr7DIg4sqCTAvWCKlgmGK0GOK91z6WPFTJgLEVHJL+V0wtAvvYjYaPY2sOC0Aoqe57eGwALVgnPwouoMjulGgRwr/GNFqajgvaDks3+yNJjC2J1OubKlkp2UjC97rQdChK/ZgLvIm50b24HJfOmKEwii6x0xUfiAY4cfkTQOUYC54KIMci5FTSL6i23M+RYCxazXz79nosCLa+GfP3O4OSn3O5afeZACzWfcLOjzufePMT5+EpZFbew1BZ6KSqrD+5YKhE1m4PyLwa/546M6oTh1Wbi7NxVxQUX31GLCVGFx4JIC94sT6pcYLmg0cfrBSi0M6ki4mMeQ7gUZL2cK56kUOlKyLhEykycUky/Ipthbe/6FXGg8rZPi7PGHcpzFJKKXodHoBfMUArE+Qdv9XU2H7JVQXu1Vop7Cxu0vNWyhJGTt6RUu8nvZNCvDJLEM80/meQ7Uw8bKGR01ngcwmFWyGNbuBoVt7G/Uv9JA58mkXVm69d4HdGacuSS1hzLzgaoxzdLn5EDVHDtfDMvrcKbcgYzL7wjXbj1pMdsK2h/lUhzdL5GVlWeC2yxOMdt3jLy48UP9jmZXWoK+qRYlKlv6yFz4RGuw1Ncfc53hEclIfq9su0hktH02pWOaiiGSwdVpmALBkuQrxlUiLBLcQIbN0yVy9zaHYn8XpaMmM6mJU627cogHU2JjLrR6WYbIyuZM3Fv/E2CutH8W9cD+HUK7yfldvUbxffhpLfsEdm7atLYkAIoR2FDBzFDOhzB7YwqFnm6lCUrpj97iUlFFgo1NdXP7x+Lv3HG2n+PwsEuPAp9S4SK8pMQtq19ZnlTJJLAon2QCm5sqZZwoxjMI49YRPkksf1OK15JJdM6mJz/9VJuIzVL6RV6t6qQQpLFg12+s1Lj26y17WLGmLGdU9IYAjGT4s4bJuq5BD84OpLZKsXfbn6efLEv4q4fEWsRB3sd0YuVtbJy5yxD8qdafxksfqwH17imWHdLcjC/rIp1Sy/SBNB2Io1Br74rw0JUqi9TZTWEIgo0jr4GsVj0mz4YW54ZcTHPpO0x0jBqe1l5bFSipXvRT7RWqAigwvsyTRBWvMEE8Gwe27tb2IVyrpt0JhZ7EHhAR2YdMQamIukodBMeh65sq1UOFi9SkibUW+sTrCau7JV8Ra3YxpNsMTXbHjYPI4poFdrKDyzC363C7Jan647hUKsGyNziisvGX01V/AYxqb6ks2iHfqU7MQuwbRdC+s6yWjDVWcU3sT9KqrsG7jaMr2ZgVGrASGrqt7EAeg5U1CayzfKR0dC7xnBL3PLX74F6NN7G2Ml1lnVYKtq55IfV3OORSLLU1pUUn28SjS6LiIWKh3QC68qOu/ifxfA45pgigpsm8EBUlH8LNK/NT01u9CWuByuUkN6ocQpgpuJUQ3r9QarLtC+y1evfhEuohxPph24x6Yw6pDeRAz0b0JnChV7MSm1IuKxW+SzORUUiyy9E+B2VXm3MUWypMsCiu2dzaB8EDu/bw6bG8JwvscWyEYirNzOvNUyfUPysiV9vi1ysaGEhwoGefjGdVUacQMT4CKmFvfQp6evj1hrOnYj1YSLbeOTyAN7TpFuuR0G+pzobUG923eM9vmPakixsnJTNLfhR4LKybi6j2gjYdDNuazkjHfZZF0S/6wKMJvK4urbXlZYu751i3qBDzdi+SRs1R+U4vggEoliXeLl1qz5DzQDk65yBOBvuQxWl2yuxsURoAHqg0M21U6vb9QpuZuLPrOJQ94nCqkuWttFNXjyS4m5cwPa32zUYWFeQysSvMv+PlgJsRizVNfUv+GLriughVNqg7Z2vbpbeklZm4Y4zwcx7ESaO6kqc0t7tWUd2ZlIwsuKP7kQ4JbZ2ynqBeVnd9vM7Nm0zM07Z2hBtJtBJujtVsrm07pk70QXXXxtsLAjtPIQZujWU0ZO/CyxakDhoG5UPeNkKEF5jOgHK7hi9p59+60EREpbPW2ZQ67l1dC6VKSu72Rw0KXgPVZU32xeMG10LgbbfbI3BUvfOFzMQZvb62XH6b6QKVBT1C7eSfan+hbuQRUyrzvFPBC3221Ig89ziMr6bZ2/NTyBiKJnES7tFmCqR7OfHFS/4ZCjsGI8eNNDtHavG8yi3sie69QxxiKEkyJ7Upscs+hs3NDtTsjWw/RRZ1e0mxR1TYmFxKLm2MNtpxae47hBZvC1vSmWGOACytVEoraGd7K6bXuk01gmzvocGbbDSJ8tOwX2j2IvOpTcLiEf5UrdbOwyUZrRjJww47JbN3HwLURevuXxelp/QS77A+40v2QWUvvpOCVBHrMTTtYwv3YAha6EGSD+7RZMFSDKMIP7izgKaAG6+/EpcmyLQDvvB+DMNq0WNFmzuesLJqGuyRXOzxGgHKwqbuvUA8Q6Xf1sByLIda2dabsYsIzHGs9UZO8QyKlxgA9Nc7cK0I0qiV++Ly0SP2t7prWd83LynWLrmHvZhUZgdiR2Ye3LsPWh2AHu+defgIiBy12+qSJA+1h/Tsc+5IKFvWS4gmpDzwOpweJxnexMIWDfB0SZX7G8QoQNrSQmxSjArrGEYHYWypoexAtnKdruKHcoEh00nB+NR6UMQAzzHUp1pYa0UVh6kKRrtbKmUG7o7jJynWznOpSYE+lqdYk8lhyqEARp1tbavM3iLkGsWkSE2IWO3iLiSY6B2L1TiUMQM+zJ84pZcxfUdUJ+I7GywTWV1Qanoja6yaR1WD184R+0rtyCR4UcjeQ1tishHAeFYxLlP/P4eP0SzayaO7+h3BZm+rqwLTVHcFiRsHmyEjzqS4NEdFZMarPokeb1apoOFnViRytw3GdEwUd4QqGh7YAa+hzAZbS29QFQHL3iFJSTEn1RYXLHh6RaZmKXh93T0uk+iqIryex6my1aDJaB2uHIWKRYj6zBWUchYIa9MBzHOMQeXLVV+0bqwlPS+dbV46PLCUkSkx8Fh8mSFpCyt15wP4y9rm+sdT6HnxrNraVnrPocMUvCodDuMoqetAfcRtlPb2HWYiZS22X1j0beIzmTEaDVX8bcfRSuroijItRx1CzYiCvCuBb2iR2TLPND9GlJxUUxxI7NtK8qlSJHWknAuB0SjLiftmT+4MxQK+hy7vl2L9Kj2JHzlZguv+Jh/G0Yc47bUy5UdUD5Tn7HwzQz6HximlV202uy/bTOo9nPxHHwatjZwuzlmFkzQjjMotsM1R90pK8cLl3zR7OR0gbB7WGt8o5HMBuDXvCNI/4SH1viPTXESyNl6dilNm7kH2nH7LXs2e49q6dhBeuyGq4n3SqieqezTq5b+nZNF2EutmLRmdqB9vjUbKEOp8NYXuSLgUeesBWH0uw0vJ7lNWCKHu54SnrnK85olLpz9srSW3lZ5qnbeJQrNL7IgmqbHx9Le4W26AcSfDUwO5dEcntiWJxhLiDPoeGmxQ38blsZR9nM7BzTvnGnAgSE83A7fQfocrySAm4uI0Rx/0ZRs+547T6HpQc6b7n0s1zteMaTPuen+KfZ/ilgtbDZBxgfdX1jaI6hHmR6kbmAaTuYdWKNipYrROWQWklZPAQI41pIwTPkNUIDByqjjL2RfkTehwo2QggKqoAUxxIsTF4sF9JS35T+JtrY42F6hePkg5IGTD4NJLC5vkOF/jhkX+F26C/mBxOCQokdZKRd4XY+LhwV4MFzRfwXaF0OQW4GFHhoNAf5AhdchSF41Bxg/5EReQX3xCNCyweagfKCXuF9eIvn8lxJdD5YWDTOxk1eIGyakF8Nei3o1WK5iTII2BATvIfaMBcSY02OwDVkFgE+RSXReHL724AoUdsd4QGKE5qkxttxckXI0C5cOXPu9QS9k9uIoB8ZKlxCRMXXl/5fe4cUk5dTQcZOCYBXkVx5ehXdl7FcRXQVxSSCEyV7GSOXCV1Bf4wigMg75EZvhPh5X2Im5cV09F9yT0kpBDtDFX4uNcxRXbODVcpXbBuVflED0SThKwPUtpfsANRJrDAE+pI0SGkxZMJilkVaL5gtYBmFYTgXNhMReJXG4BaMsmFF00GXE81+pKr4V9Nle2Xc1/ilb461/jgMnO14LQtXNlyeQ7Q+1yvgnMJ+NgRnXi18opHXM1zlenXD9OpLYXS18xAVE4gMhfvBipOkQVXEpIsT5Y8bc9fkwbOpBQsQNBNBByX5J0eTHXVV8+Dg3z13ESatoN3ijukSl1Dd3XklydfQoMngjebal17ygo3ENy9cg38FD4Q8XQZOcBE3wN/jcVg8N59f5wG11jdLEirvTcg3OKP0SvWaN0jek3IVw9fPgqYETeI3NN7kio3ol3jeM3sNxmg43XN8LedI0t41DU3Et34TyM8t4tds3wpALdA36Tt9ezEx5JLdEwgN6zey3uKHTdi36NzzeMXfNybeG3Zt0jcd4ilbjfm3P13rd+EZ0OTOQ3dt1deB0WtwzfBXlt5tfWoDt0bfYkpt2rc63YJL9fLkJxJrc2QowJ7e8o/RNbyNQcd+HeJkkd4BSPEr58oxu2CpMbeJ32d6/jQtqd4mgu3kpD0gF3gV+rcJ35wM8qk4V8X7c8kAd7S5B3yd7nfYkAwAXcp3St06QuEz113dJEHd89eV3xd00il3ixEwC93NkMPfYk5d0PdwyI93zhj3md/H6fX0a29fkwVN23gL39eGTeeXokLFkK3W98tepKuNxbS8En+BUQiKalzsgGQn53pcFkJaEWQQ4gF6aTmE5l5NddE1l/ddN3Kt4oS+ged6+c9esZL6ADF3d/9eUUqpP/eXELiXKptQvDmA+PEED6TBQPb10g/8Ab2/2TO3MN8regopYHRfs3aD3g+YPut9g8nEuDxg+XEoKHA/b3RBBffrQt4Bf21EuZPff9XhZE0T1Y8aI1jQEY1xWT+YVpNNeY3+t3L7dIWJEkTCPYKAYYIPORKoDgmt4JI9vX/KHI/gmaF5yFQUKF0pdHbh+cnlizUNqZpBWfETim/xeBgMu9GmjPOHBO6AQxGg04Halnyp2mfv62PR/pd0K5rWY0aZexgtXOS77j0YxVG12IXkKEitH4/EaMl5UJgmlhno87TMlnzOkd+oPhc99Is626XeyzoIN0y6Aa1ZQMa0z5G2xZTloLQDWGW4qPObU3joRWemwpHviZangZzmFGfdriWP8Q3k81ciqDP3pKa6MEGx4ueLEh2w6gyKddSZtTbsaK8YW7f0+/sk+VZFlKzEjPCFj1rKuszk8x5Z51K55cgN9mUEu0nLpfZLWn8aMG/0ETxZQe0kCuAbmueUb9rIqWsgxFA0bQSNSsxFjyFggz3qaOORBVxiGFL61tq65M+BIIs/scyT4+rHON7hy4pPXLTtv9ze2zJjqPYt5o8e5J26vQePazykQ7ewnI+qFIgz72TBPN8pWvB5BIKoyov0uabSwvhedi+Mr/jyZUzq2L6OmsaULxr1zrtxr9rkvCjF6onppTCYX6DVmu887exL288Si/gkS+TC6LzC8AvAtgPM2LIL3JdgvFHezWXeWOupf4gizwGx1CcfYbbcvvrF4wtCqTD66/BiqZoLZV+zgUYR8rYos1/p62F911CUJip6byKfOKLGSnDNGlFM0grYokZaOdsGLba9FjQUJIlJKCgsWylg5bIlDPMxzS0aUEKZimlIIO9Pk3NWW2DQb6mJEHAeWoxGaOI/C/tQXrQG+xvl0dCwJv4uWkyZiajOOWpvOZ7ExTpAxNYVeNG/Lx5egcIrNs1sxVLG+b66VEKJFeib7LxXrEoiSH4WKia8IOctHhIr2qxecdJ/tdaZXZwdODPM4IvLvMtwfj3L5DQJU8zF0qV1/cMkqIs0xxx776k8d6/dvcb6twxv3L0m/DcNb2y8o8LvILKX2szux1C1SLqZpSvgsry9OO/L6aBVgGjwk/3+hOQBynjXzy9jLWTPDefbPzmWFXb8yBrG8oNGRYWzmPTLOYwA8RtSS5GIZ9MbW40tMt6lY0g6sB+HH0aSwMnt2hIePi5zlrv6Y8P0n3mADRuYOyUukGXBvulSdnJZya+A+/xQsHdcqGbY6HTVQKHE3SRna+QOhq2BvOlVdSaU6WViiReJNIDJAJn+dk+7dRxlen5drHWnxYd6bGfRa9VNGJljUJbEJXEC0aetIfWG5ej4Q5RQJVTuluvCwmsEBXq+VtxaORdzmtkvC5ZtP3Eu0tCVtnokBppoBmTmF8XUQbmImmNYmdo5h2Nil+Ua5IH5Xp06ysVshKn/4z3nflAdSfUCH5oyoJS3kSaWvyWhpUuEckmjmi0dAsTV4tyL6kKh7/n1nJ/qD0TjigF4HJ/rcvw7InGbFn1MV4FGHtO6UD9v9oUj5wt9c1RyUjz5LtEJr5WuExxhSB8MIafVbvSxv0odHvNUOGWV+5AcdClV3s8Tjmp5C8pUzaxvhISY/6+rMdJ9duMvZJ/QfMn7N8kZPXxwouHu3ai7IvyDvMledEchE949JnTP3QvzvQCZ6F2dU++RJ6PH3TFYf6ss61CQZUx7EaEz5LyUMogmd9z8a+tE9D5sTze8OLos6dufPAiPNPnQcbY/PlKybeKvpnuRk/tA7VTdB2t0XKmD+duJyaHoI/kP2sPqTS1Ci1QuJcyT4zuHOSR2ffgrwJfCvzbpR0p5RFEITFe/9IM1RrEwYlLI8BA5EiB8t3t/nWeSPzGJZn8bR3JS5B6tD+Y8Yub1zpnS9pSapKPkUZoOUP2uVQFMFP9dZ0/6LF4tBqkeap7qTMDfjx4Q9IRYJLtNP6IFXxH35/hffoL7e/j5W1J/nibKnGd1RddXLUGFHLVCKUM8RhqFyHVTslaVBI3vTVR0GrJyYEpyfdIZ7wjK1PfE0fORVuK1UkxejbLDIFPls7VIdf2NQQ74lAKjjXo9b9xdG5TJyrUKv6x9FeCv8WGKsYrluI2cbKdt8eKgMNKW2sEwtYV8KX1gbRIH5hbVT5/Npp2FPGL7Ml1tRs7KFrfMN7NCIR2qB+nRRsvbAKb673fyCtDWy2qN1k4eCgMZlC8oe4Nx9/BtVI4aJkjXzVslZWn9ms1lcv80cd3Qv/ScJvsGy1/YSulT47IvEf5u2t7q7RnViGuVYGeWjBZ7n/We3FtT1sHCsJOutpoztsxbvndsKEfHEBGhdzPnm2bsWkVb6/NZ2hNiUHja/cexLUbAQgBBcC9vSXiSUKKLKhYzi7lD3gCZeHyqaegi6/dPqE/eJ4/fRJ4A5RcTVZTxSK/VbDpiTf7fiJMSPhQgE8WdX4UA8szOKXOjoAgV7XvA37YAu94A5XkxlRGvjPqaVLOZD0K8abHxPyYlgDhPxhb2cRx1leIaTWbRIc6I3YkZLviA+M9qJTQPyA+HPg1bILKCKZGRKMc1xn1YlpOSELQ+uGRCo6AGSThYbaZxMAH+SehYgbdbSNSVyLbHcHgoiZmRYJR+o/2ZmRCZbixddQHzLUOfR7uBcjaA5QBCyV6xJuBuY3UWC7ModbTBmPtJ8SWGgT8MOwT1ZxTrMIdIHkVEaFHL7xBPWgElUZIFVlO0QTpONo/2IdJeVIprnQfViyGaMI5GJUq2eQx6Iiag4/CKiKbMFg4YcTUzW2MGzLgDJhf2c0wsHOOjwRQo49aekzJyHdLrYb3QCmcTimme7AuzPxjX8aVK/iD2xQORpJCQaoEe2YTil2S2jirGajP2JMQNAwyLKmH4zGNCLK+lTIG02AYF2UNIG+tO0RpAp0RMmFH6S7U4Fbse3xVOHPgrGOIwVeSmR12fuBlUK4HBbTYw9aJrwbUSYoaZEagVeSASoJdbDJVWrwEMUPr4WChLc/LWzFMOpZ/cVVIAkDzh3bQqogRcBjw+WoxZ2AXbC+fBLLAtZjA7OgQwpLKJOubMw6UKgxnAxT5PUY4Hgg/YGuVH8KK/NgGQAmhIjwegFXvOJ72LJPJjzVejVeLGJJANKRrWGS5mEFqS8OWQIZMNljBdewKgKIHhl0N8gJqVqy0yXLRwoCKhhZKUHwiHihv1Vpxn0IoxDwSJK31Vqw1GGMhXiZYIbaFXirCMajmmDbKNkWCizUY6je6CJThWIowA0JAz9WXqgsmMlLiaFUGJxURi6HG+zjOOiTsMCVDJfLH6MyQPStWRmgkyG75obfgBq0UVLXYLtg3YUVy7yaaz3cOsI3fHawFYMzphgw6w+WGhLuwR75RBAmyQ8d8CtaXWj32Jr67KY7LLMP4qHwARSo9MkjJ8PmiH1FHhwqZ0yuMZqRyZUGSOgvJC7KLryaScISOPWtS7MeHhscDJiQKLdjNGEBQZsA9wJtQxjGaPKxQQM3ISKTEqQKPoEqMIH4jZdkpZggGiyrYYCrBSrIs8CVSzOMiIzqBgAw5VMHVWdzZNjWISLPFCyLLEdhUCFqbZUS8FTMb0HBdVHrDCcXSuMaYSWGGdQClGsGg8SIL9UH+hug3mjnHVuJJ6Mag44dzZbvRpYCTPtTslCCEUWPzaZCFWL+sA9znibKzZxKBQgxWkQbMc2IbKDzhjcBQhtBLrg7uIeBRKdM4FGSQxAseHZ4qABqxCHpAD1erztKO3zYsKSjcgkbTiTLyhbsThSzxbQ5JUU3odREZTrkBTaGyOLTjKO6hTWe2ypaBcHTpCESbPaCEPvSCENxYCGyQsCFJ6JIBhvMD6TvboaqQzbTOcIWSF0D5IMg4F6MAoV6G/KjrMUc3hssdIIhqfFbBsUCQM8L37dLWaxFGDCS7VTdQrUOsLabBWiWxWXhAsLxg+bEAby7dfhpkBNRqCEYaLg43iGyTdSQsJuhCQPVhlqFFhz8VWhHhcLSorILKGMAKg2cYJayOZpCLPZIyLqTlwSeZZwV/erbW+EzDvPLpRnrUGgNQFqY0Mb9TVNAegtTC5ROCD+ivsG8hE4MBqsEJNRug8KygPe+gHUG8SbZLv5jCNGhmESxhP0UxhzxUJzFvJpgVCNFrksXio2CHPhKuZXi3aSRjcODXjFvTOStiBXrICDsL5SXdaJxZRjBOXjh1CZzLWsAmj/oERpxSKZiVQvVQAnblZx0GsEXUWyI0rRICwuaYF1MRjZO6R9ZCQdngRLDWgvyQ+AjMeFZr4dqYE0RQQ/SclbOcH7go8Dvh4ApOyhsRqhADDcRHaWaidUIpgWrcxgJMOiQCiYJZJMF+SLiVCriiOuSRhLyjDjC2oSoI+pl0MEbACKjRyWFSiK8T7D1bBHwqUUz6mMCET3HQljlsBBpfXV/rl3Rxiswq9iWsPODZhGwRG1J3RLQ9UQAkXjjaUISgwyNaR4Q7iGb8GhqyhWqTeSIEQHLQKJSmGsa2MW3RVSUHx4SFtgkZGDTagvJQkiRjY2jci7tKOHTXAfSFqPQyFE/YyFk/Q+ginLiaeSJxhWdf8SLcOeoSiMNbQSIKQd8Fmg2qcKS6yD2pjFEgSouAEQcXGVzcQh0HIiXQTNiAniTbQ+gc0DkQerGZK9MdaTxwymSIib14OcESFaUG1r4qcmRl0OHQQfdk46gwaq2cBZrdKKgSLiZ4Rg8Qzy5BbFjSbL3ir8TZy6seJgd8E5j18cATaEL1otUFDiz8evi81VNQygn8SO0LxpICBFQh0JizfqJsScTUKF2/UxjHSAWgE0SWjq0DRiZyYHzTA+QyvCF+ZughUCDsL3jiAQsEe8cPzZNC/g1g7qy31OoIR8ERCLPXZRqFFYS6uZZySgRNrBSZsi9kEjgu8S/i8aDcEoWGAQNcd8AEsVqw+sKZpD7C2SLgp+hYlAHj78a6HO6bMyW8CBYE0UHzRtMrg/8RigtKS9bDcFESTECRSMhYbim0PqFQaVK44UCrbDglULjsa5pAiZqHd0KaxvtUGgMKIr7m8MPIQRAmhKUGDjosIHioqcr5NQ1Zj8NNhGUKX9a7BOqFb3InC9MFui6ubLS+sMHjRcXTBGIAiGgsEFhocUKgHtXICpMInhg0HnQnLVCZZCLSR8Fc+LPME3ibNLUZEiYpbzlAPi4Me+werKwrX2FgSRJB5r2bPD5UaVHSgsWpbNOeYb1wv/yMsSpRmEeZjdKIWQaqYqgYdZQAuwhOLnvOtyXvAyFMg4n7LuUn5izJ6QWFWKSNhKHbi9HJRQjPsjX/f+j0TUgx6sA2haSUUaoaJ3xedPryMsA8EfJM1grfBXSKSG7Kidc2JJUKBRbVFCpYCbyGTWUAo2RYvRXiQX4FLEHjB8c9iRfL1R/FMahxGBEpXsYPgQGcioT8TyQDMRdg7VWxg3iFWKeSBEriMfqSygwpKh/FcSbYHARRKDSG+lRMQlQzcH+fRmj9cLMGqeWjZ3wr4BiiIMrwuSYhSvXY4XFBIwiKFqaPsdaqaMN0GO9ZSqpKI+zII6YpU5fLZ7MCRROGeUogmSHh0CfoxcfOVRCwgxYG0OYaLgwToPOA2jRsZl43sJtqpgyGiT/WUKvsb57XlMDhy9PYZhvNmJrcRyFD8X0oJIjvp4o01LhIxxanmfX5GQ5gFG/NgbsqehJ2hV9bcQyTLfiAXgIiPBQ40LpToMHqLco7AqhQkfjfiC6Deg9DiiCICQcoiGhNpcySSonl6qzTN6DvHGjNOfZFpgoSSByXbipgx8zhEaYTH8ZZztDJOQ32TFFfADajOyWFKNyd55Kjb8Q9WDVHnggeqKyAFjegrCTQZK1FxMeHiPg9qQSdUcgTpMmSsSC2hEeDTJjOK1FF+cGgvYI+qKyU/gx0UCH+yJ5I7IkdzKo2NFKozN5Mop9J4/ePIYAu2FYAlkGOLTvQaZGFT6wswATfcfQtUboZP0dyQDEC5QriT6jpLTsx5g6CSX9GaTLiWiyiSKmR12Paiw0QPSUUETrZSEAqnOQtJ3sSsxNg8lgQBKCpGIZRrMwjdrT6OPrRSepGX7WQzlUMFxwoXciDA8xhDoz+LXdcsHQhbiEoWL4F4Xa6jFwmFZEgpRhDoyhTCA71FnKbiFw9CYyv2POZsQrKggg1IwHybFgLsaOxKyY/i1cIvinhCdon0NMKxmSRQ1w9JxkKEKTHUM4R5LUEptot8Ggws9j/lPai8MRhEB4b5gw+M5QK6FpSCdBtGg+OLgGGc3hd+WVTeqEBHYrCEFmzVME9aHoEqhWvh/wg0JFALix/w/9DT6S6xbvQMFbVFIwMcUMHpPOYBgmZgBeWN1HkeZGizOdKjegyqjlcfigFQxXgE0O6LOdSV69kJcTeg61FVGLUHC6ARGWRK/ShSN0G3bRFIelEbzeg2nokYvkpEIuPhQ3Ux4+vRcEEgwX4J6W5Tw8bYwKLT1IM5M6GAyDtJewPHTw8F1RO1RXynGN0HuMBMr6mCfj+owMywfAiK/sWIRGIEKi//PAzX2e9iM0CjGh0FZH0QNeyomegzNGb+gSSJTG5mIdjlsJTFYKWFxDwYDLT6XWiNyLZAHdJqhXgUHgJMZ9hySITFiQH4QyUXci2MJTGWceBgQPfxhKYnVS/SNbKWmCYxk9HdyISSyqMGcBh/Fe4boiDdKFGcyFtkHdFDQ7ZTnQNJRpAQcSPnQK70uAUjX6HhJdXEABMIO+75kVh6P3dh4AXFoiv3Nog/ZCy4gAKy5L3HIg4EXPyvYcG5MjUG7HY9agKwPK5dBBu6VXPwgxXbdinY+NrnY0/B6Fe/i7EB7Tk4DG5D5Vsh27ULBGgfDC3XPpCuQOogNENh6DXZ+5bYssjmkCTAf3CC673Wa7PgN7Z1sMmB5Ieq7OgQxCFYEFxZlH7G83H+4o4wrCmIXHHs3QnGkwHHFHbC26N3Jm4yPOF6xkYnEY4jkBY48nHo4qR59EMnH04kZLYkZnGc4yuF3Yv66PEDnExXQbJvXDnHE4aPCU4rB7f3Jm7AIH3bDALqBA4y4hdQcWTy4iXHn3dPqbQfxCKACqyLYmoi6XVbE/nAa5/nI0jDXEy4+YZNBw4qshTXGsjS4yW6UEHdyYodPig3W6j4qWehO4qnH3Y+wj24kRAR4EYg4ob3Fu477Ee4gXE5EF3EZUX3GAkXlBh4nKCO4oPFS4wR4rkc4A+4jTI7YaPFZoFPH84qO5AUJPFZoPVap4nPHyAbqhs4j3AB4wvHpOVPGa4svE640m56/PK4FIUpi1EPgDg49bGQ44wicPNLBmkHh4gXPh6WXa3Ff3BPH2EUwDpOfxBDI1PF14mCCj4zPEZ3HIhD4usLAUOEhqIbqgj4hvFT49C4xEWfE5QacidXf3FAYERBb4mYgR3Q7EW4G6B7EbrCC5CvGn4j2Dl3YvGdgDfFn47fFTQO/FX4lIg342iBL45/EuBZ3G74/bCf4mvHT0XfHeqNUhvfWogg4Pq6G4iHHG4oa7aYbbFmXY0Tw4gR6I4q25o45FpPADHBscCvC0TIqobkV5qv4ovBaHQcClgeMwYE9UgEEtAnoxPHH+3Jm5tQNJiukL2DkE0/CYEwcDC49rS4EssT4E1AkByegnRXdgk9kHAmr48m4H4TaAvqC8icE424O4RbgcEogn8Eve5liflBYEwgnoEjfByEggkK4jQ4qXT/CcgOTBl8WogDYMAkJYI3GaYYy4roaHCwE7LjwEm3ED48e4T9HKAR4Mq44oQGh/GdPHvBVglFgawm3gYk6RkAEhOEsq7B4rPExEBwla4fDCbaGe6OE+QCywSXEkPW3F+EDWBeEsFAeEpIjOUdwnBE6QlI43FBuEsFCMLBfFpE2IlLgUwQUE6nH63dIm5E426aE70DFE9XFrIfchj4DU5gQXXG0AZvG3wATBQEyHAw4rvGW4sC6f3I/Hh4KMhgWWpSg3LsiMAzFB9E3wnT4i3C4IB3FoKXXA9E2ejDE+PGIEpu7jEzCg0kLAi8oHKiu4sFDLElwlRAWEgx4zYlPYHYlj4B1D5Ez3GLERYm3gPYlpXKIDTExqD7kKQiH40h6nE64lwXI4ky4A4k3EidDQ3QLADEmPE9YLaq1EkHEeAGoiMABokwIQwklkM3EmE2HFwEq3GdEh4nr4t4hZobXHG3NYkHiHIAgIY4kh4sYkIkmCBugRnFqIbElokmh4MXAol+EFEmb43Em64bgg2EpElbE3BAciDPq76folUkiQiMkkYlr4mfHYk2TCPUfomckmkgRE+4lREwfG8k1gi64N7b+IPkkVEzHF2wjMg7IJhDMPA3H6EiAlgk03HGE7h4W46EkdEhHH44mXGNoSaz4qSh6UoI2gX4FIlW3FW6TETqAt6dm6NoJcBz2DEl+EqEiBIRcDK4g0mB6G0n7ENkkCEi8COkmyCJRF0nPXMahbElW6nOC0k6OA0nBkwK7ukuYnakyW5Bk9CTqAfUlvXSE42QfqgJkEu5wkh0mNkBIjJOMMmYUCMmBkgvF6kq+Sg3IMmrSVmi+BSMmREywmPEUYCCzZXEYyYsk1kiSADEfMlxSH0kJky4kq3SGRlkrv52k0Yl8kUYBBEaRgGk1ahuklsmp/eMlFkq0mSEZMnAJMclOk97DDk18DNkk0k/3K4BtkycnCkNcmNQIWEVkgUlVkqEi0XLMk2SYsmHksFB5klcky408mFkyPEVgK8ndky2y9k9kns4y/Ehk7xQnkl8nnkz4n7k58nVMa8mXEN0ClkzuZsYD0kyE5HEP0LMnK6d8msWUckXkmMlDzF/C+k0XHgU7cnDDQMk3bCCl53dClnk5clfk+YmXk9LB/kpCm6YI0kg/XCnRk5W7SHLMk0jKClLk20kgU1Imy42u6IUjsmUUlCkT7WCkUUwXJZkz/Gk4rinYUuilRkyglwUvimEUlikiU7smSlR8mek28lewLMkEJd8lUCGClkUoSmcUqgSiUhSmAUtnpoU8YRZkhlLvkooxKUqSmgUliBvbBCntk/Skv4X0jEPPcl4U4SnwMEMmjKfSkdQT8lGUhilvbWaDMUpykzkyULKUkkknEN7bzkzCnX6JskCUysm2UzikdcdSm8UyKndk7SnRsC0mh0f8lt4EKm7ktO5dEucA94dck3kjcCZUlCnvMOKneqBKncid8ksOfimpUtMmCk/65g7MykbkhO7VUmckhGbSnlsBIjeTJCnNUsqlNUycYTk7KlgU9qlGkog5NU5fAJU/oLvk7oQpUwak1UnqkmUlIiWU84Rx4sKnkU/yklHFql6U3ikIDDqkcUpanrUqKnCkdHazUsijaUsVQtU3tTvko6kbU3yknEwXFFASalJUs6n9U+sn0U00lE7WslxSKamy4y5jjUzalVUpLxZU26lq6MskGKbSnFosFAK4v3G7UuI6fUi6mYkvki07G6lIU4GlGk2bJfUq6nyWEGmSEIS5gU1GmGUx6kE4rFBw0sSmo0xGnUUnGn4U2NRo0nOrw0y1jY0wSl+U76lk0nal1U4BIzkgz6uUp6mlMQWZrEJKmw7c6ms03Gnc0hmkyU/mkA07SnpKbCngwpCmi06mkLUlSlLU0WkC0nKmNkWal+NZGkHkuEpNk2axJUzfiQ03mn4UrWmNQTym8UvWlGk+kTaUlMG5E9EmG0oakuUkmnCUlMHy0sCl20sslxfFWnPkxaHYUxxia0qmnW0mmmXU1Wlu0+2nTU/2llk5QCBkly4c09MZK4yTHa0m2nK3MOm/Ut65x0lCnjsUOnCyJsn6ODsm748OmhUmymLU/66Z0+OkZ01OlJ0yCkx0k4hdQCz7YUjiEJ0h+hZ08qmj3dMl9EculdUg2nCkJumzUvopQ0+0mN05GDh030zV0y7g800ul50nukF04snl0g1Rlk7tQp0umRNklz6F0memD0n2nQ0ucDl0rskt0hO6r09ulHEoemPETaAGUgYDqyMemC5Wukp0yOyj09m5702am8jTul9klelewcOllMSOndNKWk50mWnD07poB0gG4f0sskFKF2l8kGgjQUgYC1Ei+kNqGcmTWFOmQCJsmB2SOmQMlClrnHWkxkmghe06AwwMrsmdo4ClL0run/09rZNkmA6F0gRRtk8VF/0u+mlUu8CMkkBmlUvUlgo4hkXgWEiAMv8h4ksG5k4Mym46FOljU7ClWCSOnsMvUkxJGhm03ZakcMw64gM7anxk8WQp0s6lLgbU7V0u6nxkg6l8MjcDcEQqmBXCCggMj6n60yYwp0hGm2QVVFH0rRl/oVrgIM2Ol40myCDmSOmE0+MkqteRlw3JmmNQR5pZEgG700+MnrsFOlC0oQj2MgHCOQ2yBTsQMm0TExlYoV4jSk/xlWMliDOjPxlvU0JnqM/klpUpAgsgMh6Gk2yDckz0gCgH0jc4GiBZYI2q40EkDpMgYlJ6R8mxM/666khJl3QJJnekcKDQQaqBZYWXG5M24BZYTRiZMm+nMgUIBAgOJnbKIpl8gL0iCgQtJpMjBBA0aPBZMjBAZM/rg/Yz/BvYYFo8MyLqLYphD64786KklvGQEqHHt4oC5QkswkwkrUlv0mIiKwSoi2M5kGg3TZnOUxIgNM6SmRATZkjk7XFZEzZn32JcDcknenDkYJy0U8Jy7Mu5m4MhoyGM+wgNkEWh+M5xnMQd5nKMJcCBow5nGU95kLXWyCWMy4lAspckLaLYkNkdnh+MxHzfMutJLknRk3Mi3DQswPQxUDRnwskbQJEf3ivMxYgNkO4R+MuRlgsvAwvyBKl6U5Fn1kELHPXRn6MM/Fm/M5XGHXClkvkIKzUs2K7XkZcDzkzhnBMhsgUcPxmsMzFm8stGkrcKFkGGVlnUM4lngmecmFXblno6VllEMiVkshNGl4M3FkbMuXTPXfQhCkb8hqshIinnGVke8dVne8dlmYlHVmSUpllggBsi2fPUngMzFm2fC0mq8PVkulcmn7EDsgtTecmP0h1lospxmSUl1kDEVllFks1n2ACcgvYecm2kjsjXYN1mH0gNnHM8Nltk6+m7MmNnbM/1mYM2+nms2Zwhs51lTQINkQGBIhz0lVnDkNNltk9eHfMgtmJsg/HRMyqkbMrkAsmC0mhszNlVs+cl90gFmpErNnAsv6QhEetl+MpNnS02mmVs6Fzps9tl9snNlwKPNkoskFwxUkQQZs78hjsv1llsiqnfk+sgguV0kK4ydmBsxdnzk9OkjshdmmLNsm7PYtnbs0tlQslC6ks5dkDsmvgJEA4ZNsq25Bss9nqM5Ol7sm9nosrtmv0ntn5s9qD9s+9n0s55yHst9k7sv8Lxsn9kHs7lkoXatkns+9kgcjirfs2pZtk52lgs4Dkzs79lLJJ1kDsxDkWkjWlAcgEgGsk2l7sxDmPs2dn10itmvsrdY1sldnRsyiwJEcWmXspu5BsrdZ6k5WmwcsjmAcyjlM3INlusJDl7s1jmoc79mscwskDs7jm2QJ9nls+dkvkGkifs2tlTs0jF2LCmlMcyW4scgu7uDKamyc+DnociuTYskjnrnZYmLgQHGBKTdnCc/AgGs5VlhsvTmdsvDmL3BulbsmFlsc+jkWcoWYzndDkWcwsn9Cf9n2c/jkmcne6503tnZmVTkDszzkZE16nfsnzmFkxymGcgLkuc79kEsyzn/s8LlCzHyhhcpilA/Adnhc3Dlhc0Tlqc/wia4X5lKwclnJsp8lbs7DhtkolmRcgu4qVMLngcsTmrsjll2LMGToc0LL5csDSRc4FnFc9DmCs4jkDs5rlKwIzI6c1NnpOA1kDUvdmCspLlNcpdk4U/9mnfXzk38Qbk9cnXGGc0bkDc6Tl+EINmwuFrl7sxbknwVzmHEdZmvs8i6yMoLl1sj0rGc79nX0Jbn0cw7lKwA7keiURkDs6+izczrnlc99n0czTmuwOummcgjmjsoQBtknyn/spTlzct5kWjEzBHcz7l/cxhZZc7tm+017nKQ0Rlvkwzng8xrnfcvFkWjfID/cqHkI8xhbyUqNnqchUjvc/2yfcknAw8m7nHM1MDuwRHmZsgnl2Lc4qw8jZkk89RnpQ75mU867lo82IgSiLzk08xnm+c6bTcs1MDnc6lAY0hnl1SULns8zPoRcjsht9Unkk3bLlHM9c7C8qnkk44nkC8unli8wFlt9P7mgcsFmK8kXnzU59mg8+siq8qXkrEwNna8uXkg85enmstvoI85Xm7Mk3mk8t8n08z2DCOHhmrUmXm28vnnk84cg99Qnlm8oXkf8UnnHk63mu897kPkj3lYXXHk+8l+xM8lXkh81nmCSPHkS88Pk8MnbnfkHvrncoPny85tkT9UPnm8v7BCzIcn88uMlUab7Ee8uMlJ8w3lYMl8gT9JXnDc/PmA8kX5Qs0vnvck6kV8/bnZ803nl8mXkiKTPnDs4PkiKHhllc/HkAcBvnO8lFlxEN3nN8+PmsEUnnu45PlXswfm183Xk987KwG8jXlG8vXnd0NPke81YSZ86vnL89RnG3AIiJ88ynB8jynGksPmzQQvkL84vnG8rZlE8kfkdQRhZoXfJkU8i/lnM9pnJMspm1gCpk9MwHG6EGpkYIOplDMtkl38l3kP8oJmWXfkClMweiv888CVM9YjBYfpk/wQZkmYPJlNM+bkX9JsmJMkAWdM1JmrQWpnOEdkrSgSAWA4+AV/4zODQ9YQg0EEakAk7YB1EFbEzM4tCNEp+5t4k0itE9UkrMzUkIE9zlQkXHANQGig0AEImKHLgXq8wTnhUk4gcCiQhTUhwm8Ct7ZbEsQWTEPgU8C6QU99fgVzswQX/XYQUT4v4ye0zgXOUQMkqCmQUKPY/rL4xzn08qQWcCjc6yCzgUSC4Jl/Y9jzikgPCXEbQXmC3CnBiCghseWojjwKgWqYWZm0CjbFGErh6d4pgW7Y8wn94pQUxEGK4mYWCAS8UG4hC6wWmsiflN3HAh74tvpZEnAg3YWTAPM+nni40IUicvy6hCiGhbEpIXL4rHkd4bXH5Cu4kCCo4j/8i3BxCqIXFMtAWPobpmgXGAVuIRUDZc8oUe4PIUwQTIUzYGoXCIOoWNC4UBf8n+CSgGgWKCsoWIC+whtCsIXVCjpm1CzAXf8ofFAwfoVKIP/RDC/Dmm4FoXD4IoUwQHIWdCqYXdCmYU/wQkBSgBYXYwT4jjAHyCRAHLBXE3dCt3I7bkC9gBfQYBDaoJlBPoEbAo0cEmqk3wXOIZDCoYdDBZAdokioXBAmYHIDJQXNAMwJvFgE+9BK4Z4XJYAjhvCnwXmEL4VoYHSC/CjUn/CsS5p0qVA3gYhAcIMJAcIWVByoXEWaoDhDvQEuAqoL6CA0DhDPQDyAsIZVCPCinBQi/86vClUlwiujAIin4WYYFEXpoYCjGULNCS4esm3CvNB6IAxC9kZlCkYAy5bM+Zn0Cka4OIFkWEAb4VIi9kXZcQzDpoYeC2oD2BXmfkU1EOVBMITUXairUU6ikEnDYaEXeCjvHwi2UWIijDDv3NrAjM9BY3YOiBu2HZB7IPwBHIE5CKYZzBgEyijVID0Wt45oiLMqAgIYLvGsi+UWWigLAXC3BAAYdZA84fkVEIFgBYig5A4ig5B4igkUaoIkUki7ABkishAHISkXUimmC0ig4j0iwTCMi6AmMCz4VmitkV/C9NA2oMomCod87uQaZnuC5YVuYZUlFi0a7JoQMUWi40R7Yg7Gpo8vJ6/BXGkwC4hXqQYUQvacQ0kX6zeha2T13UkHjCO6bWyLmgoXPVrEZWaxn/EFw1COpIyeeSaLUY5yo+WmZhWHjHyrecy8dT/LX/A1wp0HjK0SM/6FOQvin9ArCyGHJTYCXrKYlZ+zvMEbi9ZSRRPiocGPJM+hgmIHhSydjL3Yb8UHUcDr1SUXztGQRo8ZWziqA/uApTa/opyF8JuCQLrBzEjHjqe8Vv9CMJUROSS0dXxQLcMOwJRd4KLInCVuRYHRcRBF7J8aAaPpcLTVGbazehUrxFFKIyGFB3qbuUwzAYbAZKlZ9imGDyirZAqwRhVEzOZT3pGDOyHAGCaiTSSj54tArHMoXyrWRL7hlYi7ihg8TLbBNawSYihhU1fQbZVMrHY8NTqUfXQIbsWiY8eKEaSTcOgoXYsFQjSGiMJHHGvcfWFB2Iorv+EjJJI5WSWPK8BSUGyG5sFIy0Sdo57DBKjbAuahO6JJGXWIRKywHyIJ/G6IkzFQwEQ01TVxJdHBGRZQ6Qw0YrGNqSfjdwE4pegyijTD7firSj4TZbji6dAzpWU5xojdpFQRUkZz0iexZDKka0WdCXpS+CBA8KCKNyY5Lu+AiI3MXVx7JaBl+Ymw7zjNhzfitcKd8xObfsOYxpKbUYvsVurVGUAbcjEtgQpdagtScYK0Swab3FecbSOMJ5i1bEbLUY8X3yPVimjHzxlY4tbNIKqQweNSV+CYinczSxQUg6yjxnRCRWmMSVIHMP7ukCIJlYhago6B0YmaMSUzUTMZeVMKqpgRMxCg16wDS1MAPVU0ZEmMKgJCiILYjUBTJdHvoTsecb7UWyoT9E8ojjf+RNUUvlJCRsZHaLmjEjDjYzSkLAlUZGWm6H8R9CTebhYa6griFTizsHGXxLGxQn3EApEysJTVSkX7usp6gX9QaygSZJyf0HGWO0Z4Z7DJVy+lUgYJGKEY0E2GXTeOJqgjf340y8YQ31EtGRUP6U2mNjg6Q6RyK0Nvpvgp8QfMZGipgSwyFWTHpi6TcWR6BGSCXVhYUgqiw6Q4piglavoyuQ5Rd7WzlTi9tjRAqiZ9SMrGT8VkbIBMlYUg62XQDYKUb3GQ4bJA+Rqyy5QTNSj56CAaXkwT6g+depSwUa6WkS6iWziOcVrZLSwbJU4RlYrCSszL2VtkHmVKMXfjiZDNiTFNvqqaK7L7DRhJPDT8iqZZthfeHvriyXHpRMJbL4gawmhSLqbSCUuXbRHNIO9fKpMy+JZoDORgKyvTn5XSj7RkF6VZiKNTQDJOgKLFAaoyNuU/UMWWnicaZpMKCp39UWhgDbDSCywvgoykjSR2MRzIyyXoCYsLJVy5/jrMEj4jMImVLGEj5F+aWWjuODjX9PGjNy6yjTCa/omVcOjIjdIrsZFbRIypZYydNSKIKC+UzkMqjSRA+HyhCfreBBfr0GdGUv2WTggBdQREmHGW4kRxgfxLthPy/dz4AqTRE2BOWTWFGbtsV65TikRjsfF+jw9YijV9LyTIKn54Ugz3xbCWmbDKQJ6i9c2S0zckTaS6pSSbWmavUAhV68RPoV9QKFiSuDhcvCvrB/SlG/falF9iznE84MVhDi7R6nbGubLiQ4xkSTjJXFZYJIMPLLMcfaxJREma2g4QkCINcj3PNWi0yc/T0uHayRJBel9VRBR5ZQHgDGeJjR7DOYukdQxEHftx7UfODFcG+HXPamwvUekTp6S0w7eNsqIVbWomPaT6RaFQrACECF2Mc/TtMdM5l8DKXmzUOJKlWzjmzK3bs2Rk6/GDWaprfAhG1DxVu8X1YuWHWaYSBNaW9CKjmzB16Y9cNj7WeJUtbNJVNWXsEfggiTl6eWa5KsiRYuCKS26SFH4gz/J5ZA4RNzCpUIWKpV1zGVwsK1R7ggdhVhYThX8CbhWsggrgDHHJjmLQnariD3YWLLnaP0VJaRBX/CUyLbyjKsnAhhSRaTrM7bGUYj5wuEcwj7GKSZhSRaS0SfZBSfFwKEABGwHQpEZtLixX7ExVtzY3i+KdfagOLOowSVKgP7KvhYuepR9+B/atUByoukbsrcLM/QoueAx/HA7BSUBdqn+EwqCLckQLtaEZX7K+jVlZtoatfA7NNMsxfWFvbeUAiQqWYdi26GBYPSKSzLxHHaBLc/atUJFzfbAN7A+JrANWbFUvWONof0JbLo7MnpHzC+bQ7cZWHQY+ad7TOT7WIAZDzHFo4/a3ZMqkQ59nRRji/alUUq1w7yxWEqkU/06HMayYA/M4YzWMVZ1BTtS/9SyJYEuoKDMVvoe8JmjqGYpimWKMjlxa6zDWN4YGHIar5zAyhyq+yLFHYlS3WQ4ZjPUk6OUIBS/9OpiGeCX7IQ81XWUWgoRBTYKcDDyZF2HujbUG1XOWIf6fkWUYGHQ2inlIvzACKMiX7U8pAickYGHeFxz6U/y/iG1UZMGVb5SXVXOCNSrIpKNULKukCmcI/rCw1oYbzHlVZDZpaRBbpWcqheYpo9XL4/XsVvcjhXYUDpXZo6cRWHf7Z1LYaiFzXeZ6qbIwzbWtazzLRTKTJsjCA9aBasXeLg2V2H8UbxBHYUPxS9L2ytqp2jPtP4xM0LmjeIUHgAedyiA00dWx8DRz0URYSK0aI6kWHs4E2Ddh8nRcKVLfAb9qpU7LafHau0fdU/wo3Y/ivjg5HUWn2idbTiYuqDKEAzwzZRah3qjlKTLZ4QHzQXJVUGrZQA99Uh2JO6duC/Qnq+Sa0eCCpRvQDXxA/arPqcOh3q07gQFdEarqwXIDIwFy3bQDVkSYnzlpYgZPUHI4HipewoEk9Ut0HtVq0UfRhUHI7ElTVxPqr2AM6EDavUZGiJHdDg4rNKUXq9UhJKTypA4qCrMnSrzemJhgUSxI4frW2yx8cSreIJmiUrIBSMJUI5bCKtoxqfdVkKZOyI8WqhSauDxIWJVZQayXaB8HCzQg5TUYCYoGAJEwoNq/BVoVaFyAMeDXhWFahG2HwT7qy1oQrYlhNUGu43MW2xHScjWWcU6FonYyT7q7AQMlI2w3xJqjV4OgRG2ZWTI0bzWIVX440akAwoynrCfHeTXAYICpXS0dU6UYYFSyW9Uqha3wj6E8pTqlUIqcU46PpbHybHSpQHHJizkagVxF2HtQGfYiihHBkoWmRuihyHjWzWNUy88MRx8nE+rJaj7j7q+tKmlUizOgzDW/yhjgj6YNSFhO9X+laKyQsNjVQQUlQj6SoTa+AY4kZK46oDfdWx8QY7ZQMhT0ROea9OYbQlYs/5zzd8ThqiMrwai+HOGZOKipBtWq2Uk44sNlLra4LI5WLYRbqtfBMaWmzMMZzEDHO2iraeFyNJBXAESLzRKyXrUf8VSwTWQuipauqzhsGGwQyZrUX2LayS0azWwg0LXLgcXjvq5PjqGcerEaxIqNwvg4RvMBbPqXHQeHKJj6Lb9g7uCI65sQhYRAnBrJUTqhgLcXQw6Dw5T2MBaQsWwx8HSGhoLa/RfsTtY0GMKjea1TVBHf+RgLYaKmlMazh0avBS1WHUCSfzURK7H4tUDzHvzcLDYucUpaOMRYRhG4wtMeuKKLLvY1ORYw66MAEwLCNUTWF0i06mAa/GXPYv/QRYPaDrTLeUXVjWesR5aTbi062tgv1PLRnsBhbvBRQS02UWjypbhbY8OBqXuahaKpPrRwcVQHL7Ws5DHXFhkLWbQHHcdiELYZzICe0zo0JnXvBDphlmFSIbsV5VTaTjVtqMhahGYbTwuatFG60KigefApCmeXVORNKpwRYPUjGUSqQrLzWkyg+pmEXaEmLDKVt2aFKx68BbznfhQbTExbaqJWRyLdRZqLEArAdOvaEgkxZA8RZL3Od6QC620IhI8FxIiQhYnFIg6R7VDhqLJ5r3tV+hzFMZV0SWfVjhdnWgUNrYZEd9js63QL4uGZq663CLbCYPZrsBRYYPNZj2+L7ik0YnUkcR/JfcWRImLJpgc/TALKGIeZM0F4ID1XzGi67Rq9uAerzUfdWUKEAHO7QWTka3/VtzNELs6h7Bgg9ra061LbgG3NygGnSivOa45n/cgiRNUWpvnUXXviPkwK7FeoR6vDiG0a2riVbzUUwTA2NIkxa0qfowK7ZvVqLWFirK2/K+InvWN7JrzvCTr6/4MWSY7QG7hKJvWSgQfYhkYg2i6gWRnUztyrDAXVKyUzwAkc+LB66yGubUfShyQRYQ2bzzNeAXUupUaokEtQlG6kkY/uApITfWGlb0QLwuWaRYtUC6CTLDIi16nRzXSFLbRkHcSq6uhobuH+zY+DHB+jZjyGjWvXOcROITK4DBqLHyI1DApbZknvUtLO7ZTKbRZaSG/LM6BSXp7ddLZLYKWI7d9iDnIg4DS5+ahLFHaWGAXXkUUURw7bTgkG6yjA7A6VoGiMIQ7Wtg26kNguxcGwvginVm2MJYVS4nUGmQPThUco0mLMdYEa1/wZsFHWpMAaqsGBOxXAQWTA7REL7q46hjtaJbfMS7UkeZhbgLSSrmao3q1qsijBa/QG17Vc4AOG2HNK0tWtK8tVzCnhWd6NOSQsEDa+fK6jBSYH5xmAEwJIwjERHQDansZ6SjmduSnKnDQ2sW2wfrf9ibI/TUCwriScgjVqnHWziX5e4YV0+6pqvM1g3UNZiP1CYT8oyNazcDoQ40ZbY3GF6R1jFf4ZGl3VE2f9inMAcyS7S0x96ZFrGNYdYAmfkTyYvg5HGrWa06K1YeSnTWevUeoKNc9h5yS5QCnYw4TfNNZTIvg4EWJOT2sAYyBnNlK1cJGweHcnhJyaf7qGar7+yY+QuVWqjl8ISR1lN7T+UXVl8mwjY7GGbr0SF6RqHRYzBsbJKcxLCShaQRWsSG+KwlLuTjcoSRhlRUpGVHdIerOLFlWQOysSaDj+QnrAfMW7zIJKMHINJHZ7SauHC/IFzOyGviIcprbRhPvRlzNdYmAl2iey7KAdUP05PmCAyGzI2oihWGReMbL6hWfSRASaZSr8WCqc0D1EcKNWzb1MziFJLFK2WDbAtxdOiScMURr1Dwo40W+G4mKRh+0TM1qfCPRQKevh5m9IqumQVWNdBhG4qmo6TFRtITCKSzfhPaQrUJzXGWGzx96aGTOGCwHzJPAHHWY/Zem09JQHECgZDCVEgFWywCSXXRazXqj0nNfCUIquRNLMepkURU2NUPIEjqCCSeSKFimajah5yOSj9mt8gDOb8QKrHQ4oiB/SevEtohVMpJ7mpoRwm6yFgYlUKSWTBbW6/2TiJBihvLXBgeomjxKGrywHUPOSzaIdW4cEdV8mgNw97JLqsSEYB2uJvbtsB812De9qv6cyRVsbDXO2Ne58mjlLv5cdgryhTZQKX/IoW+iQOg6Dqx8LC2GeOjYu0cOoy2C9LB7AURWGehLeucxYQCRE0fBFFxiSN8x1DZRZY0ZlFNiI+hyLb9isSGKgDFFFxY4Z2SAMVjlL2A+RRm3jJbKmoxCJN1IrELZWnjCCTpWLao1VIkzlmrtjAa8HjixTM2QsQfZ3sA5aiaULJQeXGi0qVjrwK5Xy40auTco6/hyeYy2pMJVGHRD9rGW6tgycMkpIbAba89OJjF7QXKHTY41wbSZauRM/76DNwJeWneFfG0SiFG9rbcaFf4YpFLyncYHSZm8nisG9GTO0HWTLMOLY/MBs1K+enYXcQX5upHExxbUqWhm4lSheLZqMy4VHDUcdXZVcSqFpQkRP/A3z+yEgIaAvfVdLNVElKq4EyTeuREsW5ZNmbRJDwq4F4HTi0acdeY9qHNJ96IujgGjbANQvc1IWnAo6qvOQ90NraW/MtF9SEQ0bGbXxbIbSH4uZBxwcL83/yJ/4PdcU1lCI3Z8mRsrcSQozBW9HjiW0ALfsOPy0cRhJ8xOAIXuIByVfa62ppDdwmSiCRZfW5YANLS3ao28pbea9IymhtT+jIxbHyMRxwoMXS6LbYwyos+h/teijBsCVEdUIY0rce5bsoyGgtGxqj0ROFDdFO7ZQzCVHLwhJZacJ02LmuHZNkPvQ1GIdXyECyYy2H/hx7JLy2VN1IzfNxYQcVjoLsKih02u5JmsMiRnBFBGZI9THx66Ja1LJdgtjfOohGFahkcTSS1q6/4y1e3whGKASMndY3fgUDYPnaehZ3UmCMPGsVuQMEW6kesXtoOZlNiloktiksUoYc0XIi5gX8PCwlBCnIhhYUdQewZXGpc822KEVWSREMzkH4HGQNQdIXnMp4bO2rqDRC6QjeENgUD8+DE9kYBkO81ah5AZR7v4b20bc323FqGCBARdi4f8TgXR20O3pU8/mR2mK4B2kfmR2l2322l7ke4G23u2lUIx2i20p21MmJwRO1N6C23B2oAwRCp23+IeO254MO0vsiO2rUYCiQUj3mR28u1PcprDPpQfJ6/LZAKwIDBLGuJGnbBUJduLDpJAAtHsOA6j79WzxEW2yTKqccUPwgGSGyPiUWqnebgYptH4fQ2Uj+UblPqLtHJzW8FlpWE08OQdFppTzXWmariaaA9K0yMvyk0FT5JvcQwdAsFwmfCKUemY2wkhPAFBSdcJ4KWvxBbHI33JPdF2fA9HApI9FppE9E5AlVJppS9HopMMqCfBBQbpdIqUhHig3MTNLJghD418cSoPRHJR2vH9HJmP9G/2LpiAY5RKKK6NKgYpaQiHHr7aw6DFrZYiRpfeDG/JbKRIY6ewoYs+G2SdDHIvdpi9NBuY4YqzR4YskwemScL7vPS3LrAiIaqfh2qo4UxSG/ZwxgkuUGGWoTUOp1j/oHiWO+Bh1rZNjE1YzjGxvbAziVXjGMlbl4CYhXzCY4BwyXWbRqy56WueELFuCWQzA6XpyxvfWIuStc2jvc3rP2J7hJMWN5aYsEw6Ywb6S7D9iFAj+jUO4zHm+Cwpaecr7ey2cLWYnL62YhnzySdTbfQt3hzo1zEuOrt5XhSQ4VvIbakRfzHQvcQHBYhDbMpDObWyCYyRYgNKPOAaUtQ3yQqfV7iE2qAxF+AJXi5eDrZY9LFo5G7JaWwMHua8XKMqO6QUgtiIVOcIj5yFeU9OY87i5KrEKShjEiGA3IwnRrHJJOlKtYpTG8g0FJdY6ww9Ytqb9YuYwT1AgJwGkbHD22Hpj2xpWRIqCg92y21lgLhXLGzpVtucBbW5AeoQSDlFPmNlFCSC50qxLlGBWr+3hYWyrUoWvyTQmS2Qhbl5io6m0soj51FIJa3fO6owkok53WOwF3xo7d5aoixQaoiTGiO7iQvWJ+hnfN/huhFWIhLM77NlU1GtCER2j6BDRWUbajXfXsgXg+1FfOFQxOo8k3gLETRwzTZgeogGVYOb1Hvgq1HCNFx2g8Sl3Bojx0AQs/5DwCNHtPKNHhou7qbIxNGqDfFH3DXjzJorZ1AvHZ1wQXu37O9pWHOytXHOxkxko8TJbCTr5mqNJHI9a9GB9TozJy1HQl/fJEGRACTfdIHFKpUpik0VjqVIqQKxgyr5fFFPhXpVwxclXXi3NMOQRcRpInMFngB5ACQklVOidOlISAJPuj+xeT7DI9ao+eeT7jIrkqTI+QLBUGZGXfI/gB5W+jBSvEwSywT5rI86CbxXl1+UbZGUffFF7I+F1k5F0gBeMF1k5cFYFRGZ6Y/JsrXIiR1IvO5Gi5B5EeOqqIjI15HqOqOgfI8WTbCH94/Im8pxSnL5SyLS0nfN2ztfLdhYmLzrn27kqlY87owohiKwKw7qSOJFG6aFFFQutFFLsX7bbvOJK2sBd0KuwF0XMD2jUvY42JIjXoUouY1cCkzDB2tMAHOge265aQwozV+xhIsJif0Q+WByzxjxMZSWlMNKTH1Q5gu9e1Q9aXeEXNMtLhwhxrsQtNIxw1xpNCU53dKCzwN0dni4O3KZksdOFRMU51+yr3grcQY7emmWhjNGFxo5X+i5Iv5hlwgPKBqPnE5cbQ5aeWuFVWPZp+KaNLuMIE1ZtC6DT+Za0TCf177UBfzqgryrQsfuHGvAORDwx1r/zcL7jw14STwqzTTwoGQaMZ0xku87ZUZK4Rw0CJ5rwzagBhORrtfJVQKMe+ZtvVJSHw/xqIbbEzgGYvKkWfTRag1MhDvNtjMpe+GjWnLhPwpl7ewoJaotd+FnffGrfwtSQkuPx47KsrhAI6t2gI4xGNUA54elcQDaFWBHqOgEpclEah5sH96tzYvjoIjx09jb5RZORQ4MRGQzfwwhEeOrDQkI0KxWcaF6Pms5oHq+T1AuMHhh0BUyjvImysaFSqBOqNYcInLhEHX7qjvQKGKFRoF5c0d6CIzpqXMGr5BCMRFwdCRFcOwG5l9eZibdTV46JTX5KIsb4qI/1pwjBdK53U/gNcdpxdVIZF6I8goGI2HJW9YxHCMVzxmIxPiGIFGJXpPApfAPrYG5exHF8PkzsfZIzYLbbiopaiXfNXCKA2jXr8TPxEPaPyZdyN1rOwzSV9qvd27Ow93920V7fpUyFRwtxK7yYqL0xayGIDFj72QmoTfJX7QJKmFQ6Ip8wT1IpbhYLyHi5N9y+Q9UZudTLGBQpJa0bEsII0Y2YRQjzjRemKHGxUALxQ2N6JQ31azWS54/qJNQRLTKFlusVFADM7Kc0X+wFQhgzPxETbmertgb5CuTyBKqE3OVfLenWR3KqRqGLCZF4rSKNiaCKWHIvLqF5tVAI/THL6xaccLTEFnpjfJOj1vcaFKOlb4lbSWFiw6p3Cw3dYCwnj2uwZaFjCVaGy+y6I0uCFDkUAx11/CvUrQ/aERPKFgII++gnQ5lL9wcKH02DL5tehbiR0O6GDtQaUk8ATYvQjb4YsSzYP0Bahte8RLEGWuG/UCJ6SnD6Ge+TEJPyLL4QwqaxEO6GG2rF+L1OhGFExddjnUX15yWVnwUW6DiCfHPgRLXGHZpAmGrqKNR/pILbIScUQMcDL1PqKmEKMDP6SaEhIVqPaGv+PT5n61mG5qcD1COLmFNBV/phyGozqNPCVu077zK+nqEzQy179+gYRSwhD4yw79SdhdLT9OxWFFCX7QSpSh3xMXsSjmnjLaw0xiZKSuqj2v9jrbY2EvegCRmwrpSZJV73WwvuZ8vUV3ggW7192wcXSu375sgrSFYxWTpkKC3STWLnr8gzKwu+YjJbCEUG/iYb3OuOSxHWaUF6fOUHauf+Qke8AznWV1lXyhXIagzRQNJC17VO2lQrBA0GlO40E46OJi5vC0FpOfaEVOW0HVWI6wxw6x0kBI6zTMTLwyXZOqegoTbcvQDgHLWZzxzWN6g0ZCQcuN8VnfJE5mDNJSo0qF3zUNJ7KOsUFguzWplOLVZGe0R2VPDMFZu6PQ5gn96OyPbRhnaoz7xEsFRKHr6SKbVhwqasGJvakwnjCwQ2PQXK6eWZRr9Ct6v2DpQiiBOLpO+R2paTOSCe/sFLZNBTZidJ1A46Pa9AtT6JvGixTgt0w9fFzxjg5d4VKZcG4uoQOSY2eVZgmDH9yFF17gvp5hTbd7Hgy8GGuDF34uvp5wWHr7Euu8GA+8l1JTPp7CaDRw0uoGGfghl3/M+SF/gsb6ZMcJVbvYcxcuoCHW5AFqwQhcEwun4TlBmzwIfOIzMQ9nzFeVCGB8OhTdO2HJYQwrRXOYwR4Q/jJF+cD3t8EiGccMiHg+iiHWWXZgqfGoRLCO7S6+Pr2hGVb5mWdtgt5D/iLSziHdKcB2wxOFSlBbNLjLISHZwNNLvicoN/tSSGRUecGHBxSGLLQoMwQ84OzdFN3XyXtibWdN2FudkFlRXSGCMG73iuvZ1HuqV0nu6cQ0g2gGcAqULcArcS8A39ECA63SyW5RKiAjmAZO5mRQZZHTc6ViQ3imGy8WRQFn0qsp0ZJyTqAiOztIgGQ6AnCz6A5RKLcFPXGAmHzbCaZVq0CwHgyWGjDbEC31q/ThFee4E2cPxJlMZSYHyNwFNMK3zUsZlHJwvlJ+A5LoI0JmjxhBf6hAnfgDhaqEpGCtRSBBBROsCFLcdcgFJAykFyh1IEKhlLZ7A4AyeB19UZA86CuRbxZAiO+1FAwc4eUHdGIRAaqu6CiXTA7YTE+WoH6meoHKTR9IXil+zdcEpbdSp0yZ0WvaB+bpQRmSG1patXxDAirzCceULlg8YGoOSYFVA5t0iOEzGccYBjUOJYHoGajTv5PZxPixpjjqrYEpGdUMqho4HKh05EZhlCyzlT8Jph8kFqhjhSVm64FqYoHjhckDU4uZqWI8ZLVIiN4FIgygotouoE/A0bU1GJsKAgkfTAgiJ1KzT8JI7R1nt0dpzm+SKFkHDc0EResOM/Q2iogw9LUHFPyxholjqlHEFEghsYZabqyLhrzQ7iA4HnAsrE5hlIHopeaSJAzgFvBg92X+ysQVqm/3TiPAGOJEgFCSMgHwAigE3htf4DufAEPhp8yQKtP6HhiV2fB9xynhnAEC5FHSWcCX5E0fzqW/U44+q234mBGrYuqiarNrdYJoeykru/FLye/TTpzUwN3KhP34hfAOSB/bGKAyEkqKdesJlUbsr2UKP4/hYNg6auoIyTcgE2zFcomsRUPp/W863hrP4VIx/04RRXiEyipGjaekJQME3jQo+OxSBXYSV/Y6T2+Lra1/X5peh1I5N/XKbItW62//NaQq8IM7iVaFTgMCK39/DjhiADGwXuYf6NdPQSGdP7wT/PuTxKXnzZMRpLuDKgHw5TSLehK8MccJf6JAmTTz/RX7GRl8xl9AOh7/YxqHRDRWKaMH7erI+VqcB6hMFK/7O0CpIhWVgj3/MDiP/AUzBCF/4WcduTTGD/6NdG+yqqc2Yy9f/7FGQAFe0ZDZAhsAEN0OIaeKQZhiORShwAnGQ/2FKom/SuaARkV3Fq9PoX+yV1fh6/0/hmMQVBQ8STiuqPZWbqiMJFn7ThtrqS8AtiU2Nn7c/ZLVc/c4GrOFfgc/Xn6dRhn5UykmZn1DNVZUOjlNR2n7I2PEx68cyOK/NKzDJCyNK/VUYf8LrHS/dKO8zE/0XvM/37uj8P3e4cUP+VYKY+T7RnA/lU7AwaMw/X/JzA3DqezTn7w/U1Zs/a6PFGYt3/fVH6/Pc6NlRtNE2LSqOfh5tzfhlgEC5Z76aia7AvvVN1vvAmhmKVS068b96Lg397JFBo1nQr1Q9GQxAQRQxjqVCD64SBXTf0FOjaFZPgyQxD7aFaZQpwj/jlaZIp1WSrFNSMnK4fKUbBYEbiEfJ9rYjUj6bFNcKbS4lHUfGAG0fRpTAVFCpMfDSFfehHpsfbUbo0MAFedZPikSGyJ2dNfACfW9FFIYT4r1SYhifFTa89Ob55MGb43lclgKfWT7Kfc5hqfJpHUSPmLafIai6fepGRCEYpGfAliLo/zzulcz6sWILbTHH4oraO6jo+XqrHHKg4kw42x8cY5rufNiGefYmrefbFgAzd/gBfLPjsecU7+fTFgmcCL7ulUIy/cXHgwc9igHUf1igw4HRdu1LzbNdL5TMTYoUbVWi5fT973dYyRsIsvoex0r5sIir4TVar4PQyOjM5Vg5yOIsFs/VkptfWFGbjW13dfAmjwyPWOFR1eGm1FUrlcTIQQ0GQ7axzWMkgjjgLgf8NrUBb6nsLHiy0NWhNMfzrLcXLRPPLb4SbVE5BWPBT7fFiiQ8I74FVbRR/wkbzoR/1gMKG74360XL3fcjHZu0Cjgx59520X6M9iiqPvBu71X+74Mc1a4r9SU94RwtfDbggmgKvC6HuWODFywGoTqvZ0zXQkOoY6xfIhxRsEGvTQQDnFSgmZeVqwRf/iFUPPgH0G173YZrjKAGtpOvdBiXZUYS2BV/x3UP15LvGSgkJ9FiGYlSHbtdqChUGyFhvM+oaFLISQdCjXtUihTxvQzFsJ5N6GYjqTpvBhI60bN73UIng3UceyqBNshQcLBQvrJLrlvRcGVvRzKX0W3g1giKSlOHkSDgJt5/ReUR+ys6HH0BMRxScYxsIxqK9Mft6q0eWyTMCILgJn+whehc4W26d4uMHOEiBRcHKAWpakJ1eFBZTd5LilxNetdXx/wjaTosXCMHvNiUssY97eJ6V4Pxru1Pxo8NVRoGM1RkGNZuVl6KotlY0IkxMJJ/8F4rYJVRQlF6pxGlhzUnF6hsVx5+LOMQBPTl65Ynx7exVl5UJml7WsBFTlJ3sTZCHWO4B1fLL4Kd3c2Vl7LODl4FxLl6Ko98MfB46MrGgrj/fQKL/PVpwZPHSEzffUG5PLiaFzX4JpzS4bFPCJSlPf8TlPT3RVPOtGmvbDJhKFgQNPY6ZtwuFAtPQcE2x+iC1WLp5WCJ8RhvIZ7eI05NzURij+BhUjJyJ4AHIjGJTPO5MfUIvhzPZqzeJhQ7DqCRGQ8LuV+nXoF4fOXRFIPFRnsJLrIIpobHPIhFF0LcZ767kWwo96QWOYx7WcdkTyK13RnQ9Djwp9JwiKJpN8udSZYo8ez9JgOT/PLpMvxk8PRJ+lG6PZBGlBN0J1pfrgIp4Yy0WEFFBRPuzPo0GEmBmjjOPbsEXGwfh4vdozTtGNiePbqTFw3x7Kh1hJCp7cOLg/qUAmclOIxylOO5Tu3UoztH+k6Fa14MVhLCk6P3vfugN5FMT2UElJlpLVM3aZTRKg7PWKUISi+vZ4oIlIg6nB7UHHfDij1Rzv3iFGqhsfa3I6UdER90TYbW5YygYa8yhU1KygvWNpGv+PoMuUSkq2eY+wuJLYYOpgKi3PEKgNFCdWEY77wxUJ11JeazZxplKh90eE63POTb2xrpSeus+IklMqg+uPB0oWPujYCQd0NUWN1xHEBaWvT00TVHqgAefqhk0W11zSV+0pCCaj48TCToB2PYFVIGirpOQzfDDcohyANJ2SbJI70E6hq+86gDxK6hx9Ko3GKh6gmdX6jUusSBKUEYo/UfnQfOglrydUUQL+CGg/2R7pVnRr1M0HM4R0IaEsuviImut3rQvSmhKKRVhk0Zb6gYkmh00PdOYMftgbxMb4c0C3or1FV4+peFHndEWhVG8WjrK87oy0Zb7y0DLoYkJHofO9Wg7pLWg8dZGRrMIpFr4WWREO02gl/C2j3ZTeQDS22j/7LN7nUIAGu0b1KIMKCrjEb2gqfMANPOwU60Ldp6h0fHoNvPJLf0OOiasROjMelOhvqEmjUe25450W0pGsJHJkKUOSo/XVOVyhugHyg3J6p8nLZdRgQwA0J2IaMTMSUCTMtiUJPyplm5J0+WjYUVVO9J9+Ml5ITPSCWIwGp+MRutR8Rj+8D6YiCZbVO2+jp1YZUFO79jUwvJDXu9p7URdOoAMYBwh0fLb91av2XQ5zLkMOBh9exBgxSZYRoMIh3zUVpisMXBhEO+1KticXQMWVN6lsUBj5wecL0cZtZ0MSRQRPMwhBJIhhsMMb5JKdjg8MMH1NJI2pF1YRjyeqg0nBFOyaB5xg9GWxRKMRLN0GEmQBhK/4vp1jL6MLySS+5KT8exuKS+iMY2MA8jnpkExOMERisDKVGZ0QzO5uopLCcCeFBMMb6OjV4ThMa3LavYvJxMfdKJMeFr8SOiNqA5zjFtHJilO/JibNMShFjdp7MhjDpVMcD132G445cFOjsh6p0tMTprWCV13dMUFh9MbJ0n3C9ltMQGGw5cZibNaRgau9NiVKZN50GGOJWUT1hqFHk01DYwRbMGRFF+XN6rLeN6nMToNFAOESzvaLx9B+5ibNFDOA5/IFS/WFX1hsOQLqZN7VbaN2o6PvzXMXaS1BnqhY5xEq+vUQQCefFgBpekTzddFhKOUoNMef7PF+cXKtW0r0YsafIpiQQq55J9Ts584Sc5nsScsfIqSZ10QF5VD0JcPaMRIg6MKpmck3xZVP8CFTNHO+BII5bTOkCcLhKsDTN2ib1iqsNHJ7jTVhYabx56sURaMRoKIqfB7QlNQ3Nk0sOSVJ/NhF0SRyz3UvyMR2ewIfD1j7a71iqqb1JrbQ3iSySIYK5d7aWdQOw2584THBxiPI7JHInFV43o5E0bm5b2gxcHSJq+5yX5sAuYBpjfiascth9eho0o5QvguZiIKsrINjNsAqLsuhYOdsLLPRUbOr9sGKjaZj5gjsA2jjsB50ESRQlRdHBhzsb7yM2w7pA4xoNGur5m89Fxi8+I0F7sU9hh6Ol76qUEoiCKjhEOq9iQZy3q+TCLNWam9i2bGL7vsQTRfse3Kg0Z1Hp0ZPjQZ/eQgcRrrgcM3I5JaDiU9XCInTVdM/Lbv5B8PdNOGTDhKyafwA0PDgB0X8SJZmVwSx5hmCsnJJUcJyNK6Ih17pPuTMcAdPxmI/xccKbN6bTSMBfGL7CcffNhJFzNE+JyPq+a3KAcO/KKaVXPDmAmXzu9TiLBrThWGBgSc++T4Gcf9gbaxvNCwx026aSzjCeK8Q4ejjgqCa3K77Hy3JLbx62I9brUFkXOVy6HKLB5XOMBQ8GC5j3POuEaIZiFjOI5WTNvBzm6KZv9kqp6chqp1PJ6je3LK5hXgVcNXOW5LgIoOhaiZiNxrgerARJeywrzOPcR2SbBHLUFT5m+N+apidszgdDx668ebiR2ANJmJoVqoMRbiWvUAwEIx5bGZz3VB5SF0pkhWSHcQIHyfdGSuI/T5q+pOg3cbBHxgoh3dHTZpcBH/2ig/qO4iV1IDEaEFh8JLp4ZkHijbcHj4bHJKw8TAq88XL1mAWRzI8ZPghFxk7WprHiWGIh2ie/Hj5bff4RZknigFBsJTpn9QdCIouo8Pr1M6NtZ/8IS2lOv32EfGxWlO3niJurdgqfOt5P8F2Jl8R/hk8O/hq+1/g8Zn0KOnPv0wCLkp+0FORYF3vrI8XXioFg3h0xzCTFOMahYYmopW8Sj2mg8+PsUMwiOs4czZwa+Gu8NuEHFlWgwIn3ho5YRraFXaSF+iySvTaSq8peT5ZUAhPe+533f0F0wNcKWMwFtPiIsTRiSKIf2/cXPhJqQGLeKl5MV8Zx7feXk2Fcfkbpp1IR18Gbr1OpvhqFQ5x3ZlbgSxGHgaKHQu98a4viqAPIrsdGMKK7GoK5bngTRsAokubOI7zRlxN9IiHL8en5sBtoPPCeYtvqep378d0pG0cPjPZ0/jlFsIRo5LKiqmkARDFy17y2UYuXAvotsSXxbwOT/gUFxxgMfOyzep0gwbYEsp46PEuv0MtPk8YfUY5+AS38JAROp1ARk5A+S1p3VrYCZHhyfcH11cF/4b2PAR8Zu0SIocD0sF20tQBKTN25cUJOl8QuapgcRi5qlH8zSXOCFmXPuOOXMyuy7xd5GQvkMRM7Wl0LNhllp3mmX2oAcLosIfdQTD1Z+XaCWHK6CSragBSyKp5kwQBMcwSDuuYJtQ3QJzZloa6+zx2Rlb7x2uAyTRCLwSWvMzX30PwQW0cL6j6b9R+CWlLVOyIROCGITdFrCQbraAxUOTl3S29IQ6qUp0OO3ISDMbwtIaIoTD8H/0WqwX3X6KoTyfGoTR7T2Jex4cxBtFoT5RAp0dCL2HMh1DMelTHBjQwYQHZkYQVCBQ7dFoga6eNqJbxytPTKULMrCbov0DGuozA6p27CF9ZxmUxzOUTbonCWnSZl0fRLw64Sx5wcL1vbyVhuko5UFfEQcY4oIaFhmH4iH4SsDcu4TRcETAiBD6giJvIQiBzwFrBtqeMcxjkl/FQzpcESoiFB1yWRkRoSIL5rOTEQVW0nMAScUQEiE57rLTShmNf1Pge+kRcsnkTA0w60siLxp1xFv1ciRkTkiFv0CibsryJgPIjKMURCiNnPWvNWgT8cMstvSSsndKTPBl9gs2Ccg5SV/gtE3Lp1CF2XMiF1TP3vZqT/BWTMXFaXL2lgaOyVoczeiLTLcF1N3K5Pguel1hXelhTNGk6XPKZzSvy5sQvh5EMvbcG8Nc5zTNvs+f2hcPMTR5BSth5fytWVuVO2VgQv2VpTNXqAMtnh6MST5E3WeV9BNtiCQspiE0J3dXyu9iKfKOl10SxV/fzBV7sVhJ/6N2V4OkRVysRRV2qPuhUQIrqDRIrhSqtqoixIu0NzOkA/cQDhU7qKyeWyrZc8SIu4CTidO8RwSCepcF58SiySTaddT8TOyI7B/iN/qASIiSpNBGbgSXqsesb5Jk0Uau6BAFKlLbRz+Z6bIrF8STOCHCIm8bzOeJEiT8ad9OiyJPYphI0LaOFTIKJBGxbV9iTbZT01wSIHhRJUKSJUzxIDFAgJiSOCR9MekJRqUoKcyeSRmupSTaSauEgBCqEUOnSSifKHhPcZmSfxO7q60MXo0yJgICJQQJ9meGT8aMnn9+W9idJAnRFdbKSeSQ10+SEl2N0QGbqcYKRRSCbT/qCKS0hxmOpmSDKQ1XqSJSOlK2bVKRpSAFKZSZ2Q5SeeJw6AqTlSWTIApUqT+yZaRczfE4TSMbJYoBqQ1SFsp7xNJgeopqT9V7qT81vqQTdQaTy1kaReZe8ETSVgZf+fOQNokC1lRLGonSIx1ixfOCNSCOSpTHaSumnKQP9I6RamkE7zUGybeuK6SN5kQRtO3qQPSByKmhMtGhSGWiPhLrjy1+lLe1/6TgyUmzdRK2LgyQ2Ru1g3ghSeGSShmKbgyKWyPhdGSNSLGQ3hXGTuzAmTiuUaIMBlSRRG48J5bSfypPKMKWGBEOy9ByK2MDmRESLmS7RXmQeoxOKCyeIYtUBRZdMKAbxDMvq/WkEyrZeWQKSlxLKyBCNqyU1F0V29wxKWSpWUOuMd+A8JWoj/QIRoOxXWnnOO0APxOyRWSAHH9xLqfbVEQ/QEB+P2SKyfg7GBEOQeo8ORU1KOQsFUgEDFHwINJc0qwyZOQsTMfwFzDOSw0O6r3yXOR7m99i3LRk7FyPc2lye3y1hu0Q8ULyTGBYsxVV73x/12qvvuNIqCaY/ze+XdS2OEXrziOTOhV1StKpxytvxy7xTeWsOdxTDJOuFBuVZLeToNhn2aKCLgP2ouRrxdoad6kJUI6ThhJrfQIPyYdTPyfFyMnGQEsKJ1q27BpI/yehsUwGy2ZkO1H0N9iMB+KPbzg6BTr1xcYIKcA3IKLrzoKOPz/jBHRgMWqhz1gpyC5Jopj+QugrBS6LKe2Jh/sA9z0KYwJMKA9yg0NcUrfZzoAwuqxGTR3wXZJLMehMRRtBRQMCBaLrVBMWQDhImgsZTg0rhN+QkqRSOWNg0y1PQxSiBYxSfaYCNRhLI0lRFE4VV8riiqRxRUg7/yg6TcLsBcJJuKI2q0dAJQEebn02hSYFzJ+HSMxGJQW6eJRcFpjQNFu3RsBrbqZKT3RpIlJKDhWGbnCEMjA9Z4ysqHLVODY3ivuepQozb5gZFu7StKKzIGBmxrqbUxBKuI0oDKV7h+THhvXuLtJuJUP2vROZRWZc3j6ucYRyWMKLrKWzKrKE7pVojbRrcIHFQBaKRnVU5RlRC5RHTeBS5qdCIFqdNThctmK7NoFQPV9CJfKV6KvUCZIAqZqb/1EFQndAsynRSFR6hGFQNBeHQd+zWuBQmbS3kPJvCNO1SASl7r1JlRQEqFEJdsMrzvQ1kKlaKabUqWiJ0qbDJHYJiKPueH65OtLq0O0PRT1JiJ8qWDyCqVJsiqKxQRqxmJSqTRRkGVbIQRBHRKqC5SPhBV7qqYnjtNl+zPsRDI36YOvqJqIJ4bAaI32V9zi6dj42qNeKGlClJfBJ1QfNqeIpdd1RwqL1Ru131QTxb8LmR4Fh0Qmzwi9SNTopmNRASzZSw+x5S6yGmKpqK5tEsfZsvKB5SpabZs2hV5SQKBQTWxVq0VPG0yDq8CJgm2tTP67AKxaGsrNqJ1jktn3hxaaDivUf2sxc8SHnxR8KDqBaIjqDf31Vw4IPBYWgNVytybePCNriS4IehGqtFuVbw7qDdRtZfOpu+Staht56jFmFSuKphyuRVpyuBluvIe8EDgJMZ9QWOUXDl0KyRfqIDTfsUSRshRdTAaE7oEaVdTFtk7r8HGDQc0BGLwaZAsXpNLpQVzuRaUVGJQaGGT8cJTQohWtuKaD1imjLHiYcCjSjtnh0qRidt+xFKGMaDjSzt+uZLbK8qiSf2iJRp+yrt0K2r58WRYTflLta6dtRWCsZTt/tsjtsGVjtxTintzrG5+W/MaaUiTaaOzggeFgSGaYbjQRN2PPti33Nt/NvVcGBsxPH0vhV9Sv+lrNvRVpBtHBMhVpOb3R0GC9w16BCxhDH9xhaeYLo8JdVkK2LTzghLRQd5LRApnVEXWzLSvRHLTYdyKjYQorT5nKphpOenXjqi6hVaf1Q1aKDtB+TFSNafEEuW8aIrESnadaQbS9aKDsDaORRDaKDujaGbTsefEFTaX5OJaubSAeBbRjaOHICdhKhtBLbSU7DjHx6PTkrpodxytYSy1CO7bjKcZvdCUgLapk4rqqVSR1LJ7SKqV7QS+D7SFKHWTPef1grBDqgi6TXxGO0HTMtjSaQ6B+JghK3yo6BHTPSdDLgAlxGZWDHQf17HRyRY9ZX1qPRlOEbrGBKpjSeCnSh1YkJpOPdL3ZS2riJTKy9Oef2s6IXSn170ILkAb1lOF6i5xfOFbRYXSY1ymiZSspxXDFcIy6KsYPa0QJK6K1yq6Euvw6VjwyeSSoehHXR1dy6xkqesKB2ZruIKFcK+SZiGW6K7Jfca6hzJh3SiBOCwu6ImgsS+8EWqP4wgreIY8m9LzvbeIbB6AlteWMkPEhITseyDNWMneTudhQoNy+AHzxtrIJ7dkNvNZB8z8rGNspjQvSSEM4IV6fYIqVZVYPBJLS90NNtS54qvV5UqsxJ8qspbJmzWhT7u96f+tebSdFIMfmpT6D3yz6C9w+q1iLedds5yMaOw5h5SbebB2z115EHH6B2xvKv7wqif8oLvaaXNURiIO2Z/Tw+MXRTAxaLZfJajf6d/QQRK363kKTkT2HsJiNg+QryqCX9alNvwGFuwIx5vy2zRAxNkM4LhY8dIEp0mrQ9bOAwpeG3GBJnT1qoKzbysfxWMUEp34Q7A9+YiTWmDgzjq6RHZJXgzuHMfxNiEdFzUOYCCRsQyyGarbq1aQzijBEyWFeHxKGRx0FYK34aGa0xM6XA1/eKExD2bOo6OeHx290wxVMIdUz9S4wk+BQhOubdgBJxwwtUCwLzHCYzwnDoK06L3aMGJn74uWYaePEIw+cpah9sD1KUYtjIaTEjLxGC6D51MmQJ90LFVGgAwnUCYwtgqQF5GQoGFGTIYwawoHlGCwLrabx21GfHtBCDdJNGZ7ytGOUycY57zdGFIx9GF4KDGZYEjGeEHjGHFJTGKHuzGdozzGOpaM6woGrGJs5kWzYxv8dgOh/DxJqhg4xbeYNgERvKLfgxfvnaTYzRjW3Z9eOZivGR4yVLdkTy9t4ypLUfumGH4y1qzqou9q3gTBQMZhPCExO9huqEmbQyWh53tG93S06ezyVomDPwFLEZi69p2gS2/Ex5Otji1W0kwRhyJ0c/MoTocUwzttCjy99Jky1hi9xsmJ8UybKXJicJ8V8mELaCmVPug+Zjy1MddGEZd6JOiWUzzA3QFk4VAcO2VUzeeTihWJcsEwqazy6mA5IQGZebGmKR0z6c0x7LK0xIOYIRm1B0wwOVVQQbN0wa9z0x31n0xgA9bD+mYPaPpCNIhmbfUq8BPuS0CtPfOGMzJmANRnBRMyeSlMxKbXZhevKAxZmbPsgUW0LU+AsxR1UCgJ9mXS/VSgEsDqsxIdymS1mBub1mJ1wLaXNiVmMYMODigb81rsyuD7UN9mGB33OMpHMyUWW+D8cwfViwSBD33x0ulPj3tItrfdk+xRDv7sn2LmxXefOrHSQX7tufOqHmJ7u+lhBsPemVipD29wAWaIcndgoc/mJyNWOW7slDqdz5DjIf/tv0vNuN7tG/Kby5tFJSIWXweDBT5N0ZFod1beBTYWFofWs+BQEWSIdlNkiy9sYPZWMbCGkaAYdRNujs9ZlodMWGbQ32XwdQsW7IHyeOo/CSsGS7Z56+DoSxNNx+ibDm4HjjMPQe7OHRw2QYMz9kCiKWMQOmGmIcSOdSyouFYcAMPiwhqHC36WdSyBQj3YmWcSxZZ4ywESSqKSWAOobphyyEib2pGfHFvXCSBwdGRVS+WX/IBWPGzBWeA1hWNYeRWLg1fsCGbxWTw25ASrMaedESrW7vweqLKxx+AKpTgrZQEauSzgBiVC/eVTzlWaawhLDpYh2NYcNWK7vNWGAP4DCjydWepwzUFjt9WI6w90JTbDWGAPG61JaBjaazl+EZWOzLkd20bJbltYQLqQoxbbWD1T2qNgp/eD4bSeY6xKG14ekjlk6u1G6yPBuahTx5qijm3EcvWAyPvYceNwzJSTIg2nQ46bdwS2qNTfjUGztq4HTceaGwA2poLOeBGyuG290+KVGzv/BnRY2fK2n0UvTlKMA5wdrL2taUmzwGgTxTeJSJZue7szkX7vgaM7t02eMeqDhIcNDlMegdxoc/tz75/toqsAd2odAdsqu5D8qpJJoBu9uexzfd8NyePQ7Xl2Gea8O6KTB7QVX62BDIH65YK3pUo3fOC2zm+I54W7MiS1pWcudUaMMe9wTru2YMOG5b2yEFP2zJpJIRW/EOxmJBiLh2HApR2PuyNWYMPx2MvtBSH05ygtOwPOBYcDWguzTe+5x52DdKF2bfWGua0wdMFaVOnEdiogiw50W9hpp2Ox1G8QDiX5alOXRLOpJKOUwZEcTY92WdKqRts5wuQeyZpEexwuMexXJTsLUtDi3093CL7UUSrL2fWxr2Bdqb2c3yrinMyOMU8JH2KSyJSSaU7UfscoICNbapAnW9sZ6t9hP156WT+yAOQOxXGkArBmIBzvrUBzS+ZLZ3cCAwR+F2YIOQQfIOQKNoOHMIh2EdLg/V35p+cFWzAohx+mQ8GjOAMMB4WbgFmmhzV+ehwWme7iNO+zanHQM3sOD+h3G6wp8Ajip8OcVbtacublsHn6iOAwFyK2YHSOcHxnEWSe0DFSQxxySeqOOCTjUbiyqaQR2ySEKhOWWFgdzHRIEVQpN/d8txWJQsfb1cxx9yUoe9kExNVDnMc1D5dx1DkyHZuaJxbRU/zn7eycEZRSPUteyd8WSJxWTu1vtKOJyzAwTtWKWIZmTy0HRN25SST7JwaeOJr5OKFNl2TwxSMZRO86daSrA6woFMA1w6tAbymtmQ56TtM7/+mHTOTzHBEuX+g9FEby7mrH6X8RqdHxdFwTOUs3TOHGa+SZyeLODlzPegX6WorH7vgZyfbOOgJ7OWYGHOOgLMW2YHnOVgOXORerVQ25xaagDT1TNvw4WJ7hBDcSVfOPFW5dKFyVvVk5HdYFx9ssFxSFgrRmDDnC9rBxKt1EFxIuWyyoua6cYBLHgBmbFyxTD/4dcc9qEuA6cdtYdwKuMKF7tLGjQzvphvLJlwcuLEqiVbTREuPTrd2Hlw0hQdRnjb8Cpl7GdiuVGeSuT0ENNZ80jhrH7qpSGequf/0UcBdrFYVphLWSjYa2cZsTFHorPqE1zs6M1zVjy1x3WZ/h0z0C0aeR1xvLRg7RNhniT6PBsmKVI6H6CLiUd1wK3JYWcteFRShuascRuZQPRuPGcbxbCHxuFPVG0Lpu1dTU66zvWKhtisdNZfOpljiNtFjil4s2QXJmJKvReTpNtXFVTQ1uaytNKrgVhVkKdZD0Qs5D/eWU2Q3XmJdcxLeOOIljjhrDuZ0ITWHnqJD32fduYKdqV0Ke3kxBuPeyKc0/YdTo0Ekx7uSGw2mJyfRaU3ynuVNTsVV3XRqU5guVWbQzUGbTdqWcq46AjJvuZwxGOizwkSwYqTaf2iUQ0KTZzxETAeMqihaUaEQeHBg1WMIawedti9rMziIeX9iCrQjJSKohZxcTDzmZNxQ4eNOf4eZJu4RgLSqe6jzkeDLQOY6jy2hWcr0eOzxMeDLTj6h+LotavRcePXTmMNcojsF3RCeVbSieSKJAKEkxSecnSyeJgoKeHHTKeRdbaqA5aywTTyXlHTwRWfTwgNIzxOdizlmec0wu6Kzwdh0GR2eH3sdh11jXxc6IflbmN26XySnOMzy+eQbu5uszzO1u3QheFbWPiiLxo66KzReYJt2tN0jbUAltIHNUyEiCGYmyXJqpedEuh6XLxAVMShrxbMzNR10K5RSYxT9DrzPN9pyKlOrxtBdEyzNZryTJtRElxghedePZ6yWkfQFYfrw/8AE3m90bypzqReh5fbtKLgNvGz6dw9ZbdZBz6Nux2Xnumzg9TbeWbzS/TMfd2wquxzz2daVgHI+T44Jb+ZcznBE01uT2FpBIOCRZzgH5SdmydEHAxUZ6FSRA+c/R6wmHwQ+N6zTTGHzquPxd6upHyb7G1jDKSsyh0GpqIjdSe4+YoH+CbXypZInywtKoNl+GAxBLqnzKD86Gwtenx+mAeoDGFnxkJODgv6IJAA9O7CdhGOYp0JBxC+axUgSj0xtSG4yS+e9HXpuE3tMPJOK+GicqFUoFOmIrxGGNJUpLkUS/adIwG+BgfG+JwrrfTUyxaTPXRYm3zbJBiHFGWThO+T1Iu+ddS1Sj0ye+HWw++OQc9L4OScUGBwh+cYozytXw/2A+rA6OFlNL2PxHyHbps+CnYsGQPjEOdPwkKFQftA9OV/NCXHsO3hKVO8YqdSahLl+WgzaqfbWpZadHayXaRoOh+hk0MAyo6PAcnT15cYaLvwPqcFe/UGHxywYxrDY6euVOqJruRbSRT+fgxx0a/6dzYRh/LmFQuLo9yr+fdzlj14K2L9cx3BMOf06dD5/mZOw3eXH5Fqv6N6gbMfmLzNsJzoijMhZ5RaQtNQ7T4NRTSfWofOP/yYaAyiJ8L6fABRJTH0cAI3xcsYzkUoI0hbuE5S+bE4GMdnIBbaRoBDCbyTaP44BBgxfT/ALbSJ2ifT6QJWjAEgUBVgNUBbaRzw7Gf0BLtRMBIlz66vCSesc6wQxoVQUxvxtSg/gJAhlMxHWexMBhGAwwByQLS6GQJv++jx8KRQKfWOFVc6NQLfxO+xgGR2QmPRjy7DAhTqeNxSRHcgwLgAYMzp9iqWBAlsi0ZHR2BQzuOBfPTOBPixuBIwqeBGDKlRTQo44Ayyj6c/QOYklQLcdJVmJi4cuzNh3j2BF4JBdPS+SZIL/W3bvpBWeL1l5PRMMYSyaUDxUZMPixFBPxelBY7KXL7eadHaoJwo9JcejoRSkGrOatBBrT5yJxet1AUI9BJxfYcEiwoWMJc66OhTNObeYlsIFOqsSs3/eeYLnxJJfX5DbRpSw/QbBYgxbp2gqfro2fCKi2xGL+xeLqfNxAbzRf0rlReMr2+p2zmlfWNwhrgrt4JNBfrnW/Oft26P4JBqM83s6YELnKMEIS6cah8SbnSA/aySYaQdSLjJjzR/VELKRp5H4L6FSLCOUd4hJlTRjIkKWRRlh8mWf4Uz++xf+akKegkKFEqa+nYp0GQCr1JrshF2fbO8/1mL+Bs8r7Ifb2HiIZKcij62MUKirnynb2aUIsbuUKyGRUJVKJIRkyc+yWRf5Q9YnUKfxPiT6hL+wNCf5QZEKlMf8ESolqYt3WJSmVOcFi2tyHmLlDgeRMxBlf09e62OL6RQeb98wBhaeeySYMKO6MMI0yHI2gSBMIxhD3joiCmRmceVJ7UZMIMyNMIDotFrxb7roBAvMLxb8E28JYsKBb9NrlhFZR4ScnhXsXJdzaAMJA4psKhUVkYqT2dIiRucQ9hYMz9hIP5DhfpcjhIP4LgL+yThGrfomOdFzhFcRBRTSSzhViGX1NcLn2LspB/bcIzL/piHiI8LrhS/hGy2Ph1eq2yB+omSXhTUzXhG6Rj5uNIPhTxRHcNTGvhBP5/6YNsT2SoSyXJ/Jy66J1GZoCJgqKIEQZaYh/6KiLQRQ6RwRUiLbUKpTIRVJ1oRbaS+St7dw+Zuh4RaOxuCBIGnccS4B2Yd7/KSiLv6A6QMbr3vv6UhoZKOrjihtiIriK3g1K1eyM+WTcW8GOcSbkqv5jmJOSRZDRgykBJyRHPj/iSXugTQeP/idSJWuHfhz84CSG99nT6RecaGRfUEAMCVSzTejwWRRZvzDT8QJd+yIDDJyIJd4r5cTANTORLyLdDUIxCd7ah47wKLvzkKJYaE2GhUTXRtKGKKnxeKKMsJAzJRHxSpRWKScB5sZZRJlSQR7JQRcf5RFRT3TgnbaT9GRLzFMU7M1RVZsjJXN1ARPnTCWXpxOr6a12qaRwgyBihPBa4w3SQaJcd2DJEyMaIbBtppTRYfgNaWKq2KF9Stac9gUyFaKRuCZQ6KTaInjeIqO6eCTYQxRqhbz4yLxVLznRbYiXROTL+CNSnwZgRyteAT25/F6KFaOIw9KOPq01n5TfRcIFGqPZ6OMULceD2tSzaR3QTTSGLIjoP7rB+hsHMJvfLa5GJv8PvdO1AGg50LvdyQvGIMxl9SuJiDckxWbzubimJziAK1Jjxliub6mxrcBhROboNa5BJVfsxZmJcxUCS0xSWL8xM3dMiB5aixW8TixGGHQGMzYyxRnY0Q62SfKJWIRQ2Fdm7pAyLLEOqIbHWLRL9mzDKVsYAcI2KWxU2Jm7rapw+q2J4SKQ3ybWdToZJctkeo7t4KD7cUcUmLruT2JODtrK+xT2L5yJNtBxD7e3KdH0v9XrFxTd5sbeKoMfb7Rc9IIwPgHmAbv7oPo6rzOJJLe90Crx4BrnWJPPyFfcibeg+IKcCa5AQKFVxFDM6sVAJIpj8FFRQ6QOURjZtxfqQCHzuK5BBiC9fOhdZufuLNY+GQaxe+usjJQ9xuZfM6rmeLjjMrV5KJt1rJsH4qQoGhcqK6xh/IQZpT3Nh8g3ZTG6DovcjE+IATb+zYjOkauuVEJh/O+IddluiNjIj4Pxd+LzjT+J5tX4LpNU0b/xbztSRII+yRDHcZtrHe8rsVIO5tiEoJfWzoJNiFYJU0w4JB1hQKPxuK+Ri3cQ0hKmmchLoMb4KVLwMxsW72NEZ8sKmcEpgQK5zEfyUBFl0bhKTouPgmSCajIOfMy6Q5tFZqSRIYGmiTx2Uwf1KDjdrZEygNolRLajCbLfd8bJn12zf4yvrKQN8aUi45lcDyRvZ7SHzfrDqxL2hFcTuJWcwOJWKTrHxWSuJcrIJ2fovDOnxLWsJwGx7PJQiVd2abDVXdicbPxto1lJnH+RSxJALuJRGHZxzcZ33IMpjPjtjoDw948tsQ+1Shs48hGVvzFJNY9VOMSdIYoIE/12SoQ0GapnHqDJ1mXNx5KZ8rtJaaOIn7pKVmXpJrH/X2DJNX55KZWSQTnkociB9ZTJHQcpBbxFzJSdGLJSKmlNtnU6DqlvGSzErnpHZKijWzzDLw5LYjOaTqbs5IrjS5Jk98Xwew8Kx/b6PJqRU/gbpV5IjjXiiDOx50hjIUA/JTJ2gyXXjQSGUSphkFJ5ScRLxGSFKiSaFL7GSaquSSiropZFJWSCdr6ngZtYpOzFnEIGQltwqXVGC3zeSElIfjhZirtpHYvhBqxJSelLihplI9KMXRsXAiIcpIWRcpCzdtaKk9iiae3b2IVKgSEVIHJcVKlIqVJShXWh+nh6gJ9pKIRhDKRnKc3wfS0CR81HUI6pcKSTBvsJzADM/lCSaWKusP7mpI5ctDCtu2pQByfiMuhOpD3wP4B1jtDOQdepfdFJRWcL+pSmEVpfUwhpSrHhpc9J3CR2MxpDhQO2TsasopNLQ70fWsohFWZpZngiQovg/j/NIsCItJ5paPKFpTs+IGbnhRY+7i7gFtLTFsuhNpZUzmnqpP4pK0+dpPaXiAE8+qfR9K1HwdIQpZmXFw1tZEgl83cQmdJj9+dIXopdJ/JBU8kwqhKGPLPjbpO7eh9+pHdqMSeO+QGT1I6ljZ6p/SXpOI83pfUx3pcC+U0QtXEdDlcyYLleY717vY7o35NfPNMOSZ9ezxYDJSSTHBtr2qSxSWEMfD4+ikXg2yIZdZhMSUbKvucAzKyntPCLgxS/wmU/4ZV9znzoUGTVlRSy8DfcelFTgzjMYaVoujKvuekRVI3wIa/YSyf+8ndwz13e8MBZN22HoMSyY0ckyaKEhUDYbRDZFSOMGQ/WguTJ2lE5MDxaNRFSNFnnQKukDBa1q6HrsvJuJ3RDKQzIgxEzKq78oSZ7v7jNOkpRaMZ1si8DWUYCUuepaXiXmQtzKjBS5Tpidnh8fa5T6BkE8BZHsFnaxKJUlSBQRZAE8IKLCzT/M4/xZehuJZFK+xWT5NpMAJE4TSlQP4Umj3HmJpbBMmRXH/7aaK8tKjSdyy2KpKVbHnqj5rOKTSL+4+ZuKvSNZOffLHzrJ/7hY9gbgbKhqFq89Xv9cDyYbLzg8tfzjEY9AqDOp8SGbKSglwjlsSa+LZPFTOTIIEC9k0HmyS3w0SHbJ0WfbJMSPXh1z0AJ9eT0/nZSNxmBwi/iBEmxasUiS3DJ7I4XmiSvZExdPx92fcrqI9SbwHJxcVvK89YLiD0BfLvXw8FM5FHJysQAR2RzgvysWPIibiXPibyI8YX6I/2UUJ1vX436CZ2G/gA+G9F5darAtX68o35IQz5CI8vd4QtQ30ysBcL68lukgQE3k4EA3+uM6VmZjKLuXI0ZNnJY33MdhTzC9UdZ0u1HkXIClio/E3h0v7MSm+FcZgSk3y3I83z6/b5EKu/t8G/Y3jSvRH73KlpAW9aI7ytE3lm+JiNF5o3rNorn5G9K3yW8030G/lRgqsPX9C843qTfC55m/S3g5hZJmfI55LJMr5LVpcsTm/hNdTPq3oW9ZjkW903+OdSb4Muw3mC4yV128SV4pPm3tuovfK2895JStS32VN5V+TPa3iG+63r2djCTfIe3pfIsCAm8pVoyhc37KvgCRO91iQfiY3jW8oXsV2h30W+Ad3G+x2tfjn5P3008a/IFm2VQjFJ3T7URY7P5E0tv5RY4Hkbz1gqKH4mBbHzntMMaLHYlz28cAonrQoTQFOAGfVMXQA8GKiknLGHSteC6psNVYYFc4sCoq0TIBKwoEFCYGcMBgqh6+DFO1EQpGW0izGImgpFbHYab3xgqTLJshhZEQoKjuSocFBgrcFDdy8FBgrkNwQqIKbQr+9Js6U9u++SFFAEPSJ+/rynSMCAiQrKFP7zjBQ+/qFI3a68PasB8drRKbX0GmFeiUaTdiH6I6sMOdywrkFUIMk99jR8FRwoaTZwrQsH/jxR1B+XKNQoEiCEu2BLaYwI9UtW+ROLU/QbiPsK3zhFUmOuccBuxFAHjxFV3yG0ISr4eYK0C0MW1iQIrwIRnIrulXmgC5rHT6fAAr2ur4p0GTIuudb3yZnGorWUMR/DWeYtyN56hbCL02KVFxgD1kZgKS+BY+KsfynqmngDFXSa7WWbT88MYpiPpP5/8aYpiPxZJhxhYqcP5YrE1BdibLWpobFVz4Iq13wuMR6qyhOJKGP0cok8GFSGP0PoS347vXFX1gxlTTtiPk+MA1YFtSPxOr3I7QxiP74oXFX4qcPgEo/FMiRiPmy9PFH5h6BGIoGUJ4owlBCO4+BEouTj+soldaqX8OPxg0aBFLVDIiZDPEqup7QQm+X8cklGRIm+FbSHVKkpGW0Ojq79iirGVy3ySbCVDUNkrrBBcsdxnkooAvkooVWFtI9zeVKfI4TWjgFqYVTEpNnCRoblBUrwg5UrylWOSXbapdAopNM6lf8p6FfUqVLJlLHlWetGLbQYZVfLZNncHq2la/iuW75XOsPcp5z9SNulGirVVJ61I7IMqJVF5+JDBcrVWfM6FxBKpW9KDvRlC4qxlZjwgFdCMSWEgcplVR9ZiN8j/9t2zvFHMreLYYdkfcYKD7AN4llcyrapr0RnD9J80tKCpGmwcuvqg63TNZLQn/NsruVY+/c/c6gxlPxiU7cqisVTjhtkfEHTet59R5vpbZXgGozlC9ytOhKqM970qvPp59kh25O7I9TFblSTwizripBRSZbVQjKonlSZbOcc8oQiCK0vScTF6FL60pbTKqYVc2T4j3hhdI3wIbhQLyflHT5qMWrx/leCouI9Q2CyAaXvaZyzqGyCqtp02jmD1DQe0oaiVGCApFSa1O68FXGoObRN1VcOTe1EsaLP/CoqOIiqLPkiqkFZD4rlSir3OZpwWlkV+N5+BYNJHKpMVcxZZFmio4vk5VU5EvdwuXiolfd59G8HN8cv1EJyLMp+i5PwTHKmSrvFeSoW7JSo+VVSr96s+glfOqzKWzfQCSpsp6Vb5xl9FeVGmoyqhDtkvWVFcx9v8yrntWyr4v+srDv6z7OVafZuVC4oRqrZW3Kciq+VDoLBsGHQxlYKpwuUKoJVCKo8W/0wcv2Kr5v89g8vjS0Fv5P67DfN/JVFcqQrdDZQvp7j1lFVydpxrRvLEqqhvsqo5uC1g4CKqq8NM5SWQpT4KCbuxgTdT4tVTBa70FV/djEIxgq5SOslFDg5mEarDVLPy52caqvlLVhWrXEiuqmqiVUSc1QKRaowA5aoEVJGwjIhroe2SQRFFPEyUMAioHVSkrsjI0ynVaz4XVHn4sjG6qaZE9Zh0az55Kgipiia7oBaDhQHHL6r3IlMzd3kP4pEQdgR2Tfh12FSo9WOu/V769Vw0AirMSUYsJ8bbSXhKF+o1FicY1TYr6fI0y1hPGovxHn70+fHgk1See35Sx5I1KQZrHA9O+2OmqLHIu+03uOc5U8W+NkfXJI1QjqcsavtrHG+KbNYWo3GD/LUJ1IZwmiGrS1AnRYSRY6xaMDZiqYoE9qfqdr0FqhSGOrh8BrVra1E9YByvWrupJj+6lFlg5Sa+rrSCbNW1beo21WOH21D2yO1At4iB7erISj2p6CKH4+1Mxp/eiOyB1WRqDqAz+4kEM9jsSOo7mcDjp1MNhj1eWI6NZOop6pYF2ZlPgp6h3sb1POodtQWTfx4uqN2G9xLZWho/SEDZnEDeq11buzXll9bTRSRzntOmTd1Cj44a0n24KOQEnKi1IFRger96lAs11Ak3fOFgaT1cqg35eQzD+UBjZUWdUB4BKjL1KAGQOdeq51RKTjjtN4/1SWi/5KM7H1SYL7VGhIvlog7BWihiXr9+g7ReA2gVu+oCyFZbKgyRgLaPGjeeOSRi+x78zFobz4MSVaVT/XturNqF0vjAdQNQBojworb0iLmEWCFuhyv0LKANEa2rWtN5YNL9j5ncg74NbieU7blTQNTaM1ci+8CeWhocrIxbUNRSvM8Y/vP8ZeqKNPIasNbhrsNNxaSVDeo8NB+/8Nbhr89GUd/h7hpiNLbwLP5URSzCXwyNJOrnKv7xxmLH/KNClJ36Xji/lpFyWh8WSFZ3Rrb/Axrv0IxqCRoTI1lWmjveLwzW2JvI2NPIesGBxrkV5PvAsSRNKFih+eNCbNfIsfxE0VHNOseDzPUKrE4J0Jpq9vHha1ZA0aPlZQzZuJpyPhJpC1bkc0NjuhCIzMhmbOR/OcEdo5NMRsXcAuGg5nR+HFUktlNNhtOnzbPVNJeuQFepqLSIv/NNdOELgTh8dNYZikzjR/JKGj0R/MR9U8PxHDNPv+2Dgz1Y4ZR8ipMPI769x/7exZpKbe1QrNDD1rNYJ92uKuHbNOR/kURFhrkRX+p/8MwYexrhF/q52kIokwEax9Jxj0hGDDSPv3NQDpPNFLz/b1e/QtCSUOdkahpe35p5D5qTdlH5rMMRp+gtN9rgtfHuesYNpA0EsEk64xtIi08PjItEl6aLTs2l9+MbS5+Mf2eLQ//gKGF7jEtIB0O5T4ghS0CAGa7L60tLSntCf8frRptPS0mL7pvO0wFexovgU0Yqj/9ry0WrQxNh0sgrQ1tMzWu7h68MW0ErTEdoyoI7QnUE3McrRgbIq0Tcy2hLboA7RehtnYmvzatE3MVMhQtEmM4A5GtGBseCgdBMswpshadJa0YPbAZEe8drQUjg60BTS7tJMsy4jwFKaCDWYqhtgB2bS4AdgBAbRP/HgBMAG9LCqGAkiAtAuAVvyPAJO0JvRnAgHoERRNdB5G4YJ5iOm0c35uAQQBA76lNHWqp+qxDlq02rC1WlNYko5UAX9wS+rS3rW0TewdCFwBM7qKVJ344rTttHRaZvi81D20DlRiiCe0xPBehjU2hcy+yL0aRvATtEfCm+a2nLO0LLDztDVUqSZatMg4DDiGIGu0R7wYsGhqW7TDwhoB3LhwcG60JD4dtDe0dUY+tK4BP/5XtB4BvQG6Lg+0b7RPtK6Y5ZhvtKuKEdhftIB0v7QFmgB09CKrirBUmkiZiMq8En6ksJI+rn6wdDlwNToyfkh0vTAodKXeJlq4dJh0rpgwCDomeHQHAYR01n4WLs5W3s6AMIn0J0rJ9BUijHQtSEq4VGYcFAQe/vRcdAVYXYx8dGWmoUhCdAzuO9rfUGJ03iIHgrG+0nQSHucIw/DydIXUGyLKdDgIqnS7tlswew4I9Np0qu5BRFC+BnT4TA9oSOxXUHCqmGgYCMoY+hBuaiFwtnQo5OOoaugzkOOw+bCudP8oHnT5sN50vKh+dAbQGoTgHvtwj5iEZi9Q/igRdEACLFiI7h3W8XRemM3Qbsr/sKFQ8IzRSAHEvPS2mCxucm6DdPl0Wu5iyBwWZxyp/Cpqbkar5r8OWx4qLCO4/uz+Xg10N7AF+KBIrXS3ePr0x9DdDEb0g3S9dBsM5oFq9IKUD6xwxlKB43S6HiMownwzdFseOlB9tmaoi3T3IEKaE8YrdHkoa3SHdGUimGjdWEACe3RoqNv036Z3CIjuJJz+dIGcA8gPaNd0RfzFUFru7Gif/N7wz3TN0K9033TFULby+BBfdAnQ7iT+gYLIj3SYxKNIIPT6dLCaWx6Q9PJ0MPTdDHhECIFu8PWoBlDUymj0PczzDF0WLGa97p+M406MRoT054wkcE2wZKqjXjtQ/nReVJ1KFHDp0hxwB74jjEz0eSLl6gyM7PTxdJ84VIyTwrPGP4wEjG3sp7DC9N4iAxQugeT6sEx1gl5wPEZdSAr0PXQlpC7CqvRHger0eKIhaD10OjhWgQN0+oEG9HsM1oHtdKb0ou5Izu10/z57DDb0yKIBNCWiBQTvXirUK4GJXl5wHvSOHnxOE8ac0Eee/vSedMuwCg5VSLoIjXR58EbK9nwc9IGc5iigvt90NHTCXsn0U2LboOiQU/SewLaS/IouoG4K8WANioZcRoqwiiaKMor62mWKGpLG2oEKPtp8kNhAtYBcCmzylxJJCuuQHEHE0j9cmRAO2iNAigBYxL9gjeodkmxBStqyhNZSadwCQVnaWEDxaMvinEHFkhJBezqK8IngskFCcheAKkGiQQlsykEKQWqK4PDqQSXaG4BJaBK6akFvXCpBwdrmQVyQGkGm2n0QpkEGQSNQlxCWQfRsGDKzELZBLEHyQX8MNlCGQUhSEeY+QU5BpRAeQeHafJAOQVZBukHs3GFBrkFGQYJBMlL+QeXSEUHg0v5B0UFBQcZB1qDCQTxBV4iasrlchFpn4nxB7kFpQbS4GUHsQT1g2UHo4JpEeUFuQRHcwUH12q0KmXIlQd3QHBAVQRpcJPgxQXJBI0D1QaTAKPJFXLlBLUHA8tVBhUHcQZdA3UH44MVBkkFiQeVcNUGa8l5B0EDhQdzysuLxQVdqbUEXCspQ+7LXQOJKDorKoCRgehKUQU0SCzIMCrra6SBtiobaP2TfoCtB9wzsQV50f+CuQJ9AyqAEIAaKjYpGXDRBSzIBiqWKQYocioFgB8CP9ArAILjfYvyKnkA+QDtBBAqPIPAK2tov3EjAw0LAXMdBCoqnQVaKshAkJDnA2UDmYBqgNMDbQeraFEGa2p4K3oocPAdBplzmkNDB5YqBYDagHJYewIDi+xD8il5AKMH3QTtBmMGgkk9BTIq0QVDBb0HtiswK5RChHMNBG0E1isSKaMFfnBraNWBeCs9BMBL4wczBJ0GWEHDB+8DswdXagaQ7IMSK1MHowfpcehB7QZKKEJJqknracooswbDBOMBFiCAAsUBSAIgAoQCpQHlABACoUDgAhkDGQEPkneAX5CzivcI7IC6gKACIgP4AxABQACwgS9BgAPAAhSB4AHgAD0FUQf+cxoovQX4KYsFAwLogUgDYgAjij5xD9BlQwuLbbDWKj0AMIAZAAABU8cHewUrBPoq4webirSAfQRcKb2BLpGxAc6Q3CrmgdsEOwTFAWIAuwbiA7sFPIJ7BycF0CqnBUorpweugmsGSAMHBocEIEiMyRiA4HO8Sk5jZkHHBicFVwQLBDMH+wRnBrMGcimgQEVzkwQXB9sGOwSXBrsHlwUYAlcE0wfzB2MGbYr6KxYr1wYHBjcEhwWHB6fRV0JJBkYq5oLHBCcFJwfPBYorVwTjBtcGQkm0SmcFD5Lgg99hvYCsQOyAUAOpA8pLUCrTBhoq+wYLBK8F+YHiAe2JNwWsytUG34q1YpJBUkLrgecCAIXfB7+CFQeOgIiAWstySMuAgIVMQQCHgIbFB9wBwISqKYCGXEhHgOcCi4Ncy6RAQIQAh8CFoIf0SeCHQISUKvUD/CnHgt8HckvyKj0C6EvLBnwAQYFxAUGDUQf3BUBDyXqYS/griwWQQ9Qit4OEK/IoPwU/BfMHHwX3BzYp4wRfBRtrsAD/BrAohQcPgNBCtMptAflxVOFPccEBfYINBMiGzQHlcE+CJHK0y6iGIIe1B+MCaIWohSiH44PohXOBRMqQhSCHWoMYh5+CMMuLiCiFWIcohFYoo4rNAb+CgYBfAoBK0ISqA9CFkQIwhb8HMIRDBkxDLMprBqIqhErfB+cH9IHwhvcGLwX7BQsGiIewhQcEbwZIhf8G0QG6k8pBp0P0SS+CAICA89iG6IVdgeRD+4KkhMuDpIaPB7do0ABAhhSGxkNriqXLjoPfYDuAV2sbgECHJIeUhIdroIQ0hUeCpIXUh5iFRAOQhx4aEIZHgmSE6IZpB2QDp4O1yWeB/YDUhxSGBCp/gvuL7YHsoi2KPQL1c7iHgElra9MHCIXXBn8G/IGdBFsGMLCTg06r3wY/BESESijXBKsEfCqvBlpDiIfEhJtqeQagQcMhb4OEKb2LXIe8Sv+I4IR0hKdpxko4QuFxejFAKjyHSEINBmuCvIS/iVFxFADchJCELQD8hgKHnXF8AFeBadEChWSEDIWWIRoLH4JCh9yEP4Ify9FyDQXAhyKHG3J3gHyHOIaihDiGuwAihMcFq2rzBGMELwQchp8FHIW/cl8HBiGYKHxKLYu9Aj0ByoC6gcqDpHvshYMHQ4odBayE4AN/B5yHMQVIhYVz32Bn0E3ARCiPBOJKSEDChdkF1QZtoEhDc8qWAjFCUEF8hYJAqIV8AEhBCoR3g1eDCENXg4qGXIZwhcqHrQFkSMVw6sPKhwKGHQIVBBqEUEFpyiKGGoXqh4qHTYmiAGfRHEvyKgBCVIJ4hdCFCITraY4D+ITEhgcEioM4Qu/K14PyKDCAeQOPAgND4gNwgDCBFwN6g70CowYDQTCBtoDLOOqCgEPGhbqHgwYGAxyGcod+A68HNwRchfKFuELkhzhAFCrSg7hBo0mtyxJLTQefyc7B2soUQKoT5EFjybJJ2kE0yjpDj3KMAEVxsYCUyLcDAwYQQ+WDI4PWhDpDuAJKQzaGNIa2hXQobmEygXaEdIaEQCRCiCkWhlaGpQR0hyRDdsPmhrtrVobGQ4RDGobaW5RCwkNIK2/CykvZg8ACs0GgA14DwAJ9AEAAQAPAADCC6IHpAR8GKwSfBS8FpwefBAcGnISAAEiHZoYkhWxDSBNdiL2AGkq8sHsBrEAoKIKEdIZ2SwPgqijiEyNz09P8QIGHtIdkhctzfobsQTuJTkjBhXTpaoTmhuSAIYeqQw5JAYRZwSGGvoWMQ76HwISBh9hJgYR+h4/LfIQBhvoDwMG9g+DzCkBaMOxCIYf0hEqFzgNRhgCC0YR2SjGHTIUSShUHvXDRhCpBfoeRh9HBYYWWhb6HiMPtglGEE3CQkTGFoYXRh2qEcgGJhwmHc8kYKbGH8YYvy0mFykM/iQjJAkLhht8HsYaRhgU4/QZng69xUkLph3NxPIVBhITIGYeyQemEsYWZhnsASMLihJmGcYdKQWYg8YQ5hNmGQYbChv6AaYdX0JRIyYeZhRmEkYSZh8mE+YV5hKmHWYaYh/6H+Yd5hIWGykEJhHsCYDIphZ/INoDphpMEikvph1xBJYUoItmFuYaZhqWGbMulh7NysYR8GVUGJkBxh+WGHumVB0GHkYUBghWFmIf5hhGFpYYwyAWE5YaFhJqFzoRFh5BCmCh+GVWFhYZlhDWGVYVFhumClYTah26AA3BdQc2KhIaDi9RBXob+cbKHLwRyh41y9CiGKQ+QT3Hyo+RA78LvBHGBeQOLwrKHLIe6hqyFzYccKZyFZobyhlEA9oY2h/hLOkDGQMVwbPtsKz/L7MJJhyGFFgJp6tBJXYZcSS2EukD2Qz2EZYYthj2EiEvJIa2GuQN6gW2FMISsh96GDwYEh6aBZwOkE+RCM0H9hHgAA4ZNhBhLbYSmhIiEPoaBcRmDnYQlYG5AfYfyK2pCA4T4hwOGqwSchqOHKihpk65Ap2lY0LiHsAIHI6kC44Sbi+OFpoXthcOAHYb/BAmHHMoGCd5DV4O9I7LJYlM2QgVyc4Xdh2GHrnGzhPOFxSCoyU5CF3sLhy4jSQdVhmWFb4jxOOBCS4ani4uEiEr1acWEpsqeQt+R7kLGO3PIWsnLhHOFwUMZhmWFvYGlKquKwUNrhQuEm4UDun2FSYWK68bgW4aLhUeJK4YBgOSKDYcmQQ8xWKk7hpuHZkPwhJKGCIZEh78GzYbw8jGCbIVig+FyzKBqQvCEqANTh8OFKkojh7KHI4aDha8FM4QkhLOHpXGLosdy6JoihaeGH3GpY/OEp4RZA2TD4XDSQh9Id4Jrg/YzYXDnhueCgoW5KFFwV4RdipeH4XDWSUuFdYfRhI0D14enhvFCZ4WXhjeGq4TlyB+BDIkyCluF3IVnhclyW4a5hLeH4wM5QA+H24fjAbeFi3KPhBuHB4V0oSlyW4VQh5EEKwVNhseEzYfHhhOH+YCKgPYBEiM4QPDqLYjtQUeELIR4KdMFA4TthIOE74V/BUoDPoUdheeExXNo6apCSCH5cE2gv4TMhY+HW4bS449I+XK/h+OC/4aPBn+EL4d/h4uLv4driMyF3Ic/hEBFNYTIgpqEFLHFcfbCIoc/h/cCwESUhHSE4EK3KYWA4ehdijVyZXLYIPeHi8kVBuETi4BCg7gi4ESQRQBFoERMhshB4EW1ApGQxwXWKPuHXocmhceG7YYHh6yEcIQrSqJw5pKL0O6FEADZg6gAHoUYA8AAuoCHBfaFn4btBN6FRIR/BDOEdEEnhL6F54f0Q7tzYXPyyHZJt9BDcq+Bt/LnhSmH83N7cW+DaEVxBkRSrXEIQWmEmYWdAYVZaEfHc+MDGEZ9cahFW4fdhzdyFVtX0VdwVgBoRWtz2EV/hjhGdkq6MqhGuEdwRBdxRkKLyfmGZYbLiPBECXPYRIDJUqhRcnhEL4RfcjhCrXPTEgOAaivMhxKHr4Qjhl+FI4ewR3eK34VwRYFIa8IsaNYrjwMlwsUDIgBIRaREP3FjBZKG3oWfBBOHpodyhh2EcYZLg9uAykImS0LjK4Z1hzWF2Yc0RHRHQPO0R6DyNQToR8WEbgPQkvRGoPP0Rv2AYqA4RAuEsQKMRsZCtER2SPRHzEdHgLuFuEbhh46C9hJMyu6FCEdJQ8AAGQGAAWgCnYSw8iyFVEdNhd6F1EXIRGaEKEQ/huhEsQIoAi3L6cJHSZRKPEUMRauEbgPcRhPIvER2SHxEiPN7yIBHeET8RYKB4Ak8RvxFmEaERgJHuILdcIDJlEvdUhBHGUn9ii3KwkboKsLg5APrhIRHj4e8Re3LyAG+A80FAYIiS5whwkQxSgJEDEolBG9JyYIwsTeFdEeCRWJEkkfNBxJFDzISRppL0kdwK1dLegAMSf6FUkRiRuWA0kZmiR9JskbyRXhEzEQiR7sC4IIwywpFZoEvgnRFwEQBhxJGSkSCR8gByka8RveEXgMSR6bDykRsRUpHoEXZhqpF/kLYKNJGOpIyRP9w6keQyrdJaEmrQqxHlQe2YyQoIBH9BuaAxUIPkxxHn4a/BtOFX4RcRHBFcoXfhPKHwEY/0yQoflHny0Vx36JawmzLH0ByR0pHmEcVBvpHzYv6RvKAxXAjOMEB+kYaRTNxDQa9gAVILYoUKhFqRkSGRiZGS3LGRs2JJYVmRo0EZkXugBZGV4RWKM2KWsE3adDYU4Utia+GVERfheOGukfTh7pGSYAthF9x1koVgMspjYR4AdmACEXuhFAAHoWQAohHiETThzRJZEdfh6aGekY0RAGGVYXfCaxDkEezcEZKZgnOR1BEcYYuRwwDLkXqRicaxkL/4K5EykZEWLOJMOiVSr7Bo4oeRgpFKEYDsB5EmkYzS74jrkY5E2ZGcUjeR/ACG4KlyANyFsLeRQ550YW2RnyL9ilziNYpg4tHhSyGZEWwR45GXEUqKgWAn4p8Rn6E1ij2RghH9kbsRYhFHEQqSUhGsEVvh2RHtEpmhzOG3ERn0gbhV4jPyUFA3YlmgQOj3kV7iBFG4UWPisoR2oGKhSpFEES7ifxTuIKqhU5CjAD8SVFGlkSZhlBBEiPRRWRLsUTYSC0hroVqRMuFMUVmgvFGp4r/gezCz4kXanJElqiKRPRK1EEwR6REx4UBRqFEgUc2RYFEXCrRRNxCf4vyKMFF9kQehfABDkYhRz8GkoWcRtRFNkTkRjOFPoV6RHSFD4lrgfAoFoasSctiKQeMhECHg2PtgmxEy4C5RqgpCZMRRQFDl0uLg2cS64B5Rb2CbEWeRWFG+UY5RF+IK6EFRoZH8UVyRUQAOUaoKFdo74v0RHEFOUZyK4+KbMsDYuuJEoY6RyFF+4b4hAeFmUR6ReREWQBuiTwCqEuQSWlHbEXBRg5EIUeUROVEvwY9BilHnEaZRwYoYUcnhtxEO4ATYZVHjCHkSp+B5XK4kwuJ15tMRj+H9UUwSYepiEqOKY1GFHOQSIVHDEa1Ak1G0EggoE1G4RKQSC5xgkbFRaOJ4QJISLBIb4ADgmcgiEuli3lHBCntRwjiEEjtRlxKdUa4kNiGmDKxRFwrUEvIS5VHJEbmgNRBuIRURa2KnEZvhzVGUoUPBgWClErnizhLQUVVRB6EGAPpRdVFIUQ1RPsEukWORbpGFUVcRFlFTkf5hvyH7MleRzoBdMOrSu5HhYcPiYtL1YWjRYRKuwEdR0jy40bYSJRIFyt4S61Hf4TESVAjE0Z4SilI0EC8ys1FvEa4SslLFoS8y9hJI0ejRFpFFgDGAmKDh4c9RNCFvUScR9ZFQ0cBRMNHBiv8KVRJWIddB3ZFA0QhAoNEjkftBJlHfUQ3B1xEQIcsQMeLkHlkS2aB7MJigQqEM0cqR2QBq0WPgL4g8kvchXFA3QgTRYxIe2qWS0hxTEkihUArG0XrRRBFrEnRRReiUkhRR7xIO0f8RMxFa0QKgLFFMku7ROtF8UTQRlRKDEvygY8H9IDUQ9RIAUR9RTVGK0TtiU2AbIZMhYpKSYOiSlVG9kTsRING1UfLRysHvCkrRieHw0ZhRc1FnABxQUQrIkpuhpdEW0eHg5dHtCskS6CHV0WiSGNGZYWsS1EgN0brgZGH4kT4SXtF54XRA2Iit0U9g7dEwQG30qQpd0bcRPdGb4kPRmtFWHHsw+oB4iJ9hSdF/YOOgtpER0cCS0dFC0aORItEtUR2KidFDYYUyyzg7IBLQiIDZ0YchudHx0Y+h9+HdofaQp2EZkq0yfVRP8qAKXorDUbcRl9x+MjAhGtyBMtgh6JHf4RUQN9EHMsWSETJ6ko3Rv2KFMrfR0FHe4fJRgFENkdDRm9E/UVnByApxEqAE+9FkAIfRq9HOkevRSlGi0YxBKtHjob/gfjK0sjgx2FIloYVBJzL7Mq/R35BugCQxQdEX0Q2h5REAChQxd9HoCg1RYZGwMYAKlCG5oFMyR9HkoSfRbCHeoeDhXhicCp4QgNHp0dVRctEoMY1RkDEb0XnRZ9GWUZjR0WH2oXSRdWgSEFbyI9FF0TI8iVqeUWVhuKBhpBoKeSCV0XOAYdE0oZDywpD6MfXiEzKO0fCRxjGbCg/Q3OJZiNoxK9iP0SoxWjHL4nYx9hKOMaKhSjGf0QCRCjGWMRMyIDJhnLBApjHKMYzRTDJ+MaOiMDICoc4K1FHwkWdi9eKkMRWAFjGwQB/RiqEtYbhhsmDyUvYSCeicCmJclDFzoRkx/iBZMdiQuTEwQOkcujGMkIUxlBAIGMjcrjHlMRJRTDGLYXwx1grh0eNhtZHvUWvRCtEUoafRE1zFUaWAnAoRMdWRNRCIgHgAbgChAPAAg5FeQAbB0AAYYKIxkNFoMV9RHTHzYW1R3RCnCubBGhIiUCI8WPL8is9AbkAlwOPAbkD4gDTABkAo0K3A+IBykrMwKgAcMTUR7TFMwfRB70GKipORm8HJkPyg1SEUPDWK3CBMIK8x8ACxQAQAGABTMSnBnDHMilcx6sGiwRggDRGF0UExNvKrUGqQtVJL8q3aVtob8snadtrM8snadaRbEjnaErqJUdFcVdobkLUSwfKR2k3a0ZGl2s0geLEosZixbdr52rba9YDBMqixTuHesoHaudqe2qfyYLFu2mixqXLgsXHa4whwsY3aNdqV2rHaUsEl0jEKVBKYsUSxG+AksbCxlLEisU0h3LEF2gix/fLZ2pixhdpksXSxQdHp3PrRXIQW2hnaiLGrUOqxMrEl8n7a1LFLofCxM14csU4QS3j6sRCx0rHDMgRBNwyXQMsoUtHbAHKg70DFEUwgVQBhADAAoQBRYFUA48BoYE5AjmDGwQ6R4NFGUZ9RtRGQwcLB1zEawfnR59Gj0E0AOsEoACgAjgAuAAbB/gDmQKAA1ZB5oN3Bh8HsAMgA6AD6QBbBv3KRwXNOsIBgANiAn+CAmMfIjXpmGE7iqkAAAF7LuI4QsPAUEIJ+kliEwe1g8IBJsSAA2IBSAFwA5WDmQCAARkCSAD5ApoinQLmx9uD5sUEABADVsc6AWzKFIBJgRvBBAM6xx2GX0eURRxAfAJIA8kBqQNiAsABzsUyAJ2HlEaux2IDrsWOxy7iFIGwi4wAoALFAsUBeAGCAlICQWMQAjMBI4HJACkBOweZA4wDtsZ2xm8A9sSAAaoApsfvBPcGSAJmxcgBZwfpwUoxQCp3B8OBFsdugJbFmAFj6JHbfYlWxNbENsblotbGNsR9BzbEQAK2xL7FdsfYA77F9sTDBIzKAcc9cQPLkEbBxE7HgJtOxUoAbsVIA87HUMcCAS7GxYOwAu7HrsZuxHgDbscCA9HFEcRyAk7GiPOwAp7HnsWAAl7FogNexRAC3sYsxK7EPsUpAaCDocW+xRkCfsdbiqbEHwcCAf7HZsXr8IqGTEQWxYHHmQBBxVziYYuwahwAHsXqA8HH1sYq0jJI8MUGILbHmwRJx3bG9sewA/bH8zMpxyxDjAGxxKijHscaIM7GHAIxx2wDMcXzAaEDLsXRxBsF7seRxlHG9oSxxvnH7seOx7HEkcZIA3HEXsVPISUC4UDex82D3sVIAikBQAE+xkgAScR4AUnHBgF+x/NEKcabBV8HkIcYqxTKFscWxGEilsd740HH2cbpx7HEkdtH8L9ZGccCx36AocWhxHbEYcUhgRkADsYMhkeBcgBVxoXEI/nhIGpBZYAcKwoD+cUyAaGAOwfJAYACOYMCAbaEfIBXILJhk3HgAWQARcWexUXFt6DXYgghxcQgS5nGYcW1x2ORTIfghd0AOcXfUfXHTsXtiw3EeAKNxmQA6QJNx12GgCp+04gCv8vcQC3HAgJFxvHHRcWtx5gAJcUlxKXHsAGlx2wAZcc0AX7GvUTlxRMGOIQShveJqcfYAomjQcWVxpbHdcYexHHycODRIcygxIhKAcwpRsS4ApnHnCm2xzXGhABZxOHGyEB7aYPGeAJVxvXEhcNOxQ4qzsRRxI3ETweNx13HACjsKJX73cZ5xFUBPcUtxPHF8cTFxErAbcSbaW3Gtcfjxp0B8nETxh3EBhGTxznEU8a5xVPHncTTxV3EzgNNxDiCzcQ9x8xCs8Vxxy3Gvcatx34Cj0J9xj7HicTjx6XEfsZlxMnFzIfJxqAD/sXlxkeDdITpAEPGRAAoEpXFuJJmcMHEk8TIIxSx1sRTQyPFi0YKwmPGnAKAAvPGnAFhxVnH88R1x4uDdIcLxVwpJACdxZHFucewAHnGOQF5xtHEgAKxxkfG2kAuxQXFrsYdx28HFGCexqvEc8WtxgrDc8YEKPvF2AH7xIADWcaR0e3HrQTJIxPE9cZHe3Qzh8UNxifEoAD/BzPFMgN5x8fHBcWdx7nHJ8SJxqfGO8enxVdCZ8ezxb3Ea8R9xInGJcdrxZqC/cewA/3HJsYbxRKHA8XdR8KHn4IDglvHFcXsQtvH8cPbxcPH2AH1APVGI8RDQdbESYEOK6PGe8Q4A2PGvsXjx2HHtcXCh9EBC8Y7xSQA18WLxcwqU8QFxp2E0cSnxfnGJ8dHxrfHd8VXxvfEooS9x2fEa8bnxgnEI4gXxRfEl8RbB6KGF3IDgIfEbIuTxj/ES8ZRADfEbwU3xHgAt8QnxkvEd8VRxXfF+cT3xsQD56P3xK3EB8O9xWvFicePxuvF/cfrxAPEycU6hv7Em8YpxtBF2obcSqnEr8UVQkHHT9LDxo7FV8d9CLvFGYm7xW9HDoI1xZnE48Xjxl/HWoEBg/DG0oWnxpap98c5xp3GJ8TLx1HFK8YtxKvED8erxAnFCcfnxwgnbcQHx1VzTkjBAm0AHcbgJ6Ri18UDA7fG94nTx83HKCSAA//GD8c2gaoCgCTtxpHTHYngQRxJSCcYJsgkR8RgJ5gkzgI9xVgk2CWoJMIDD8T5xo/GkCQOgE/HvsdJxXRDuQJ+cc/GqXORgYeLMCeBxrcBGzBgk1eBh6BWxjvHokMA0dYDLUEhxP1GCCVjxDgk6CUWAtxKjwRqQh3HJgM3QpHF18V4J+2ITcT4JSgnPcVnxtgmxccAJm3FaCXzxoglOEXOwGxGb8exx3oB/oNUJpgnyCfUJigks8X4JzQkBCbyA9gkdCb7xjgmLYfuQcqi9CZwJ8PEDCYYh2XAucZ4AIwkWCb4JTQmqCUQJQ/HBgEUJXQnJEGOgivJ9CRjEovEbCZ4JlEAKCSgJrYDK8dYJkwkHCXYJRwmzCYXx8wmPnL60WaAwLBcJOChrCf1xGCCbCWYJdQk7CY0JbPGECeKw73FvCWfx2gknCYsJIpG/CSsJE7EAiUMJT/EjcaMJ9wmHAI8J/gkvCYEJMIktcXMJxQm5EPSgvth/CZUJgwnOcTcJGIlgieMJewmQiVex+InNAMcJ2ORnQBWh2hLIif0JVwk/ZMCJ2wkNCXSJEIlq8XiJ0wkEibjxcInY5KcJcqhm0dySFQlogJSJ1wk1CbcJmIkx8QKJKgkMifxxTIne8e8J77HwiaqKK4C/0bKJqIlUiYqJNIn8iTmAOInPCVCJhwnMidqJnwnboG9g3bD6ibXghonciQNx1InnccqJlgn0iUKJVomvCTaJsImdCdjknsAFZE6J5IlyiesJPInuidsAdwkqieaJEwn7Cb6Jmomn8YSJHwnEicGJsKBACpXxqwmuiUCJUYneCWMJcYneiQAJfolaiQGJRIldCQ6JHUBkiZyJlwlVCcaJwwm1CTGJXomCicWJSYksiaR0wYnwiJCRR2wuiXWJCokNiUqJtImFiS2JLQkiif6JKYk6iUGJitryAEiJOnFcCeGJgIn7CnmJoIlmie0AFokJiYyJY4mliROJdomnQD1gwmFhiUaJ/YnoiR6JQ4lrifGJ6omc8WAk7YkLCaqKFGGHiTmJS4kmiaeJq4kPCReJPombideJtolpieXcWaDnCTWJ/wmPiUogvImNiZ6JuwkjiVMJX4lliamJFYmvnPCIuCCH0r2J8omRic+J0YlgSeCJaokfiRqJW4nJiWKJgYkdidOJywlzidmJfYkoSQOJpokFieeJRYmjiVBJO4k/ibkhcwpsYEhJEYluiahJ+YlYiZ4A64mXidCJ44l4SeWJU4kpCWXi9ZLMSYuJwEnLiU2J4EmYSa2JOEk3iSMy04nYUT2JmQkLiWiJCAkUSRxJsABcSVhJV4kzCdBJk4kdib+JNdGHXCJJKklbCaBJZ4lvidRJkEk6SXRJsEmCSfqARklKSUeJZEkniWhJ5knYie+J0km0SXxJMEkCSdIKKLAPiaRJrEnkSS+JlEkWSRBJwoleSSIJQYkGSbsQPODGSfWJLknsSbGJVEnhSYmJMknfibZJBWSxSQFJyElBSYlJK4mhSe5JlkkRSdZJ3kl6SUPk6YnFkUxJjklASXiAIEmDia+JRUmpSZ+JpUlRSfpJuSELcopJ84lOSXlJqkkhSepJmkmeSa1J4okESYJJnUk5SSxJuYlsSQVJA0keSTRJw0n4SRVJ04lvYLdc8UnHiX1JrkmNSZxJc0lWSaKJbUm3ic0g40kASRSJk0lPicFJm0mFSdtJxUlpSZFJI0kVSQZJNSGGCd1JtUm8APVJaknJSWFJUknzSXtJd0lySYJJj0kTSaJJdUniSehJqolPCRuJ2Em3SYtJXwnLocGR1UnPSYFJU0nnSUlJzYlfSbtJvEn7SRoSCIlVSYDJJkkgiRJJGEngydxJ1onbiWVJu4m5oYdJgVy4yQlJG0koyZJJRMlaSTxJpMmYybIQ3wmqCtRwWYkoiS9JOABvSf1JH0lNSWjJJUk/SdDJBEHYyezJ5Qk1SYjJZ0n5SQTJYMm4iTdJC0n8SaR0pwmcChaMq0mSyblJSMkyyaDJw4mCyQrJwslKyRbBbMkKSdTJ60mmSQ1Jl0kaSTtJQskYyb9JosmbRhIQNmFrSc5JtMkzSfzJV0nNSZDJisk+ScrJpQlCSXkSzsm9SebJ70moyQzJQ0kkCclxOvGvsXrxkQmAkhNhGbF0CblxX5EjYTFhOzLL8eBxyxD28U+8VTjacZzJkQD6ANmEiPHK4nwJ+QkY8ahxQgm6SeTJKGHiYSNYecm3BuwoeMl8iZbJg0k0SUAJGgneyeVJGhLjEK5R8Mnw8XtKgMbAydNJssm6yWHJ30m2ySLJEsHKoanJXUl9yQ3JNMnByXzJocnyyS1JBsk+yYth3cnTyWGJ/cmNyWZJW0lWyddJK8njyYbJdDxTyZsyukGyidvJ88n4yTrJKUl6yYfJzMl2ybhgAvJnyRLJ84mXyWbJ18luSR7Jd8leyRHJ33G4STHJBvFRCW5A16CxCRoS1pIwoIkJ6nHfQvD4fwm+IIaSPSDu8SZx5cmFCd+JF/ESiRApmYkh8WsJA8mvSXIJtQmf8a/x2AkMcQQpnfE+cd/xsSI4/DfMBAmMyYAJQYh58R3JlnHF8cSJeKCTEGsSMom38eGJuCk8yfgpz/GLsbHxb/EkKXwpgilSCeH0wqo0KZ5JbckgCdqJ4AmPnJkSOrJ/CXqgYfEeCUPJN8mfSaPJ6MkPyUhgsimyEPIpKdGKKSGIyikbCbwpIcn0ycvJXsmrycwpXQlPnB1AXXEASUophgAmCdrJX8n7yZ7J2kmWKTopp0B6KUMSBilQjE4prsnDybfJGik2yVopvvGeKZwh5pJ1QL4p9/HGKSDJLiktyZopuEndseEp5UHmkvYKdcltMDEpPIkmKYvJZimWiffJSSmYcSkpLBBsKW+A0Sl7DP4pC8kXSbNJB8kWKUfJhfHFKbS4+DF3gHAphkKccdkpcSl7yQkpISmFKdopLClYUkuAn+Ih8czClSmfyV0p1sn6yfUpVimsifgxz2BCoTAJeSijKU3JNSluKUzJvSlhKf0p6WDPYOEKwyn1Ikspu8nNyRMpBSmgCY0pNikiPHFJuAl+KSopyMluyUvJ+Sl1KaEpDSnEiWcpYKBt9OUpRikdKaop8SlHKb/JI/FfcVHJ5WAeAD5AscnbADjhtAlZsUnJBEHfYZjhBPigcSvxXbBsCYgWHAnESfYA9xE7ULloWdz78chxZclNcZXJwICNKRDhF2HxkGGJboIo8TzJnSmXSWgJbfEf8WQpX/E4CVXxd/EVKaspdCntYAwplilMKQSp52FPYbCpKKnscaSpO8mICY3x7slUqanxNKlYCeQp9KnLuIypHynmKdpJf8kAqZJxlAnT8VEJOZDG8RCpgWBG4SGoduEakOnJ6nG00Gvx7gzIqRkp2/H+eLvxxox5CWDhyCm4qXRJ6CntScbhHuGW4QspTKkfyWKpgXEcSSKp7/GkKeKpdKkhcZQpyOgSKa3J9CltCTzxaCn+8V0JXAq24Q6pEFBOqR8pQckgiUgJocHuqXHx6AnCKcQpUgn+qcypdgnyqWQJ0ckUCSCp7AA0IInB6bEgAGApQthV5LqpkPF6RCvU8fpizn8JLlzHzKTAicw8GpapBQkDoPJAIQmRyTmpgKl5qUApHgCFqT+xCcnqqWpRLSoDiuDxxbEP7FgsEfQZ6nApu/R4cIYwimQV8bUyaPEe8SgpbamicZ2pYQnkCZPxSql1CVEJ/anFqaWpNiwHbL5yR2wVqdbxr+xbsBH0zXgzqSMswmjIIrdIEzLGca2p9GDtqf8pXamKqfmpeaAxCYnJP2D94cvhEFBnqUGw0PF28UapwvHO8Wapf/h1cQMKy6lWqRXJNqlhqdjkh+E5iAJcjqmcKbAJD/HLiYQpAilpqa6pp2GscbgJGak/yVeJUintCXiptqkQCVL0/6mvyVKpofGOKRhp00kJqZSpyanUqV6pbqkSqb6pU8iEacEpCsnZqZupuanbqZ+pj0CgKT+pK0F0EQziUCmQ8fqpiKmGqbnJYGk78SvG5qlQaYsKIhZH8aupJ/FFCeRptqFYEeJpAEnSqXRpGwmqpvlJWGmUQB6pQilbsbSp+Gk/8XgJGfGZqa0J7cnsqfipzyl4ESqKLY66abRpbGADcYZprsmMaUmpIim4aTuxbfEEafgJtmnTCbxp9GDhCVPxu6mAkqkRh6kyUuERjKpL8UVx4HEFcYip0nygabfxyxDI8QrAMnhYqaXJx/GPKWAJxIlXEBXcq4itKWeIAqnmad6pRCnsaSCJn/GWaTRp5WkhaVDJRImaaUNhCRFG0UjcIfGenndAcanyCdLxnoly8bGavmk4aaxpeGmBaVZpCcxCobKpOfFBqfZpUykcqSwpdID4caVpbmndaRVpHgA+acKpzGmiqaNpAWkUKVPIk2l3QNNpJMnrKamJrWmZwLPcHWnQCZwpa2lXyfXxQqk+EKZptWkWaeNplCmHaQGpiSkaaQhpysmpgAXcCWmtKbdpLqm1CZtpj2nbaZ6pqak1aUYJUTRHafcp7inzaY5puonxaStpvKkrQq5I62nbACDp1Wk+qc9p3qn1aQdp0OkfaSVJYWnPsVupEQm9qdsAqtpqqabxIzJrEE8xEmFjqUkJorgGqUrAirQO8VXxX0ERcIjxdACB0EapCdECCTipcGllSY0pDZDH8LmRBilGmPspx2HRQCgAXsE3AeKwb5A7BMfC7/7BsuNWz1BydkEWsLbC9lGOZeCqRug2gUwNcLdm3vi46C8WGKwD1jRYeObwYteMY/ifgsNw/XboNuME2Xq5ANvu3vg32DDIHpr/9M9QV1hHFihwvKap/vl6pCK/sB/Wb3wu8CfKwyxKKGOMBnqYTiX2R/CbNCFe5lpfliS0o7iIFCT2igh5iF1wtezO6GXWBXrnaBz8ywSOZM6682Ro9kF22emo6i/eptCrMEYEKALcqlsBZyisGt8aLxYFeLaGzZSlNJJUbcwgDl7w41BwBnR4JbylNLdI5lpbME1Kx2Y+eHMsurQpIgEB7liTLA5CR8KKCNq+q4qOtKIuSvwLlo60K7ppWHCIxeTrKOoaZLAgerU0MZqduF1wC2bLpjDUUDilevDs4mzxKPEWdJiV1MZYXMh61MGoIw7yGEfCooiU2q+YYgFsyte0vyhgbOBWaGpYFMXkb+lvLDeeLLCFybbY5IgQ/AqQ8lTemEEgByzQ9PWeaZhIZFrUBEiyTrS8FbRxGCPoICwZAb6oVxwNNqrUvHC9rDk0YGxKaJ8ux9DHGLh0kVA0LiBwOQFzUIWBH5hL7k7CDJhNWMtQahT3NDocQ+o6JlYIOE74sNou72gCbmIUh3ZtMBkQRhxv5K9mvMjqzKF0abRJMB4CHDYGen+wR0R6FOPGaBB5QrDol0R6yFSYajDuFPco9cLiMIbM+zxqFCgkNxiKwhzwH5QXnG3IR9BvtMSotliQtH6cvtggGdQop/jfwpaYT+wR8PVaqYiB8KDOSSQXfFVw7My0GGVQOiZT2EjQDsgAaFYUuDDY6i8Azbww8FKGUTQ2PpgUsmpIKOIAfAEI8GS2jCjiAO/wvMjsVPdxo5QfDCGUjCjW0DUU2HBIKISICj4UsEmwWBgwGOXeQuwErkHYbJbKvOQYSSg7PvZsLZZadNCaxd49WOQYbtidfNGYqkbpGBNK+pYBqJawEOgMcKAUHgKw8H229qBW+DTwuaSZDMhI9cYPOPPC+viQsmTwjNom+NYBrRQU8JH2N9iPmMZYXyyoPgmEYxkxflb4YKiyVMZYB8gWBNbQBxkDmjKUGkwW0OhGC2jIuBpMrDZslkV4rloi9gRGZeC4zBpMp9bv8HH0+MQh/s2uxd6N3uA2tSzl3gA0QelCSjTwGAjDLG+6LJSs2GksLuldUV0UL8wANkVqXRRI7K74v4i5RmScQxqiCFN05/D+COg2BsIfGeWkj+SpkHrQavC6CEvWRTBFxkEws/6JxGiZdjaEmcyU8xZEfkbp2wSgFKAYXoaiiHkJuxaUeEvWvFDrGejkAqJq6TfE3nr+xNyZmzAsmQ5wcgIEyLYmmPCOHNyZsJrJFElGaulymTDw/8KymRNQtegrKURpM2msqcGpmglkad9pFUmepPkQIegZKV6KlFCS6ZVpbGmg6X5pu2kiKZwpOCmE6TdJJGkhqbpJwul9VD2Q58m4CRLp1ylGadLpsunZtuT8v/qK6erpg95QZN74wZlVcJrpRuna6VdqEewS9tGZe0R0mZP6BunfWM9Q5umfcKIIiuk26dtwdullcUD4b7SNhEa4Eaxu6bkAHuladMhI1zTLUEoaRBYAiGZ4j6yR/vmBWbR7jN72PrAOIifK1Brh6c9wcem1PuTwLcK59pkMVnCdwrjKNcqQPpvou7w56cL4WjCI5udoj+R56ZYZjQKK+s1QRgSzvK5K6wSqaEIicoJ16StQDenZUE3p5M6H0K3pDHZ9Vi3p2cAsdj3puHR96cx4SajK6bvQeSRUmP4i8+kCWmlYNQjT6QvpT5ncSgU0r5kHeg9mQTS4okr8a+nKAesBWXjfmke8dTAVDFOwYGxIqN7UsPAQWcnIhBSt6fH+Wz4B4DfpgBl36b4OD+n+NEoYKbSJnEp6h84z2B/pSnpeVO8q7oY4WbouIVBBIoAZHRhHzIskxeSvcLQUcfRgPtAZWPCwGbR2kX4IGbMCSBl8tCwcTnDiqBW0sxSoGT4WR7yxyOGqsvD4Gc70HYZJ2JtmpBmzlHHUpTRftDVYHtBHFjRYp2YqGcJ6x2ZOpPSYbGKMevqMHDTZhC4UkeqaNIsYUfBDvPwZD1iCGZMwKFgiGYRcBnop0AKcodBg8NoEMhkpCHIZVKgbYBWuzelZtMs6ahmmTns0fCQ9yIGsGHqU0HoZFd5vNMxk/BiP0Gl6ZhmvLp6wc5laMH3q2sg3eHYZhnhIKBRwqiJoQq4ZCVpXKNGYjV6EGJ+OwHw0nP4ZebCBGbg+BVmMtut+GqglWRY4GthmnP4ZnTZ0PvXwry73cckZKpk1WWrGuxbb5hEZ2RnI8LkZWBgZ/PMWVTBeGSUZ9+RidiwYFRk08FUZ5chCfmNZ9DgOyJIo0VQklrw04Bi28CWUHRmiGH5qYxn9nl/o/RlM8C+Yb+TbWRpMYxkMIlb4kxlFFjY+N/5C7GMZVPgAAohe61kY4SnpfOFkCLXwzZnbGfMZuxkaTPsZJ1lHGXsZEp4llKFkJviXGa0UuOi3LP/I3UJkCA8Z3vZshB8ZN3De9u8ZWj7AYDQ2KPDEfs/UiExq9gCZoJmVOuA2IJlk8GCZ6DaoaJCZKzyGyDCZcQBwmRosY/iiAR8ZVKQomWSwUxZbCBiZIdRomZ6ERv7R4FwUavANJLiZJbDl3iH0ZJmtUMkZgMhUmT1Y3npKKHSZT0K7FvBIrvh1MCB+rJnC9kmu9PzySNyZKyh0xjY03JmCmZkWIwRhmaKZABRKKAPWTCgZFDKZYZlKmZ1GgVliNuGZAfDNWWP4jVnqme7JrimamSdpX2nTKR2JbpkroS/YfwmmmZEmdUk5KZgJlplY6SmpFpljaftp+clcKQ6ZxykyKcSJQBLDsT+I4uke2OaZTHG+mVPQRvzhuFbpipmdDvLpoZlm2frZhXCRmXGZ5OYxmeCZ+ukRmYxkUZkHbo/YJITQ9JAI6Zl+jGVxP1B+5DmZ1ul5mai0BZliNq7p+LT9vC7p5ZlvtJWZ+/7+6bWZWHQ7qA2Zkem6cByGH+QsIsto0el25pHpj6TdmSxZ3pRuZFb4A5lp6ZvwkfZAKASWNkQP4GXpU5nszmXpc5nL2W72S5kV6bgqaPbV6W0wtekwRqRovTA7mWr+7lnHZgeZ6HaoIvuZJ5kAvlgovenj2bdausibZsPpFHjaHC+Zj5lfmXYB0E6z6e+Z4+m5bA5CqtTJDtq+/5mBJkwwm+nAWYEmoFneePvpEFm/UL/kx+kwWascGmznGnF+TuakFMhZWrQf+PfpXNZatE/pw2xbCK/pBj4WnPhZaX49IkRZRNTkOYfOVVnkWdg5lFnUqtRZITR08DPUVBp61DAZbFhwGSyw0zCnaGhCxrReZp/UaBk1tBgZ/Fn8lljoQlm/lEVIjrRiWdFYlnDXmVJZE5S2AiQZVBm3djQZEOh0GXlo14itMHuUWkgaWVLIWlm6yDpZfs5cGQZZ1zDeLlsBJlnUHMd6cHTCGadYVll1RuIZdhjxFg5ZRhTbuGHkChluWXuZKhnyTF/o3lm7/r5Zbcj+Wbh6gVlhWQQZ9CIaBj3IJhmotJFZrxRpMOdw1hnxWbYZ53BJWTYZThmdOOlZZhh18J4ZWBi5WTDwRnjkGAEZwHzFWYwooRkB8OEZFVlRGdVZiRkDdsqZ9VktWQD0kRRDwvU5GxaHMB1Zy4hdWTpQPVlxOTrw/VnFGdkIQ1mtxqv4B27xDlSsE1n2qFNZ9RlwyI0ZZPCSUAtZrRlTFqBQ0ECHtOVQ61lqKqUwW1mpujtZ2nGc8KMZ8xmHWRpMx1kXWTMZehRzGQ9Zl1mQPtdZ8xm28KsZ5XDdGZsZS1BYaAJ+lfaM2dmEIe7zGZ9Zb1nfWRWUv1kudmYoANkocDf+dxlaPlbByfav+JDZrxngAkFkkNlw2d74CNkfGW0C6Da2MHLqeKqx8BjZpuZkCNjZhj6RqmTwoso0NswwuRR9siTZKbaImWTwFNkANlTZt/AHMEvWdNlTFjd+uJnM2WTwBJls2cSZjLmkmWVx3NnI8LzZoXb82SaWeNB66cLZ+b6MmRL2zJldWZUoUtkcmUvYstlhmfLZlvA8omGZytmY8MKZatmOApjw4pla2adU9vANJLKZSdlG8IbZetlJ2Y05fmSp2WqZI9AamdxpQdl6mXbZqlxPyEaZvckVgGiAZpnema7JxmnN8WDpZmlMcS9pftn4iHwogdkPKadpVrnoUDa5P6G9kOLpRphkqQSA7tlR8THZcun0bK05YZmdWf3wnTkS9r1Z1BS9ORL2g1lVcGUZyfijWVVw1cgf1mTZtAijOaTZk1lVcLM5xgTzOYN6TfQAGP/In3CLOZH2XRkNcD0Z/ZkbOZNwuzmtuTZpZXDjGS+YMnCW5KdZdhinOYVwCxkVrpc5nbnXOV/oQTaNuZsZXhjPWZ25dXBGFPsZxfD7POYUJxmW5O04Ba4rpMXwgNkkKMDZmvwWsE0IGJT+pgbprxmgeojwBukwudrIcLmAIn8Zbcio2RXw6NltyJjZGfCCdAc0Y1a0CNCZ2sj4uZ9wYdDUtLKobvCfFsiZ5cgUuVVwNNlIKDS5MfA4mY8upnANcEy5LBjs2dB5bLnxWRy5GJb1+NQoPLkw8ILZXhnC2dvwQrnQ9CK5/fBiuVgY0tn+FFK5jCgyuTDwitn+GQq5FiKq2Ywo6tlhGZrZ/hkauTDwutmJGQa5irgFXqx5zxnxGakZ5tnSmcu+NVk6uRrYKdmqyGnZJ9gZ2SXZ8yQ66bGZEnlQCAmZXhlJmf0UPIxYGKXZYxmDDNQoJIhM8NXZObzjHh6azukfuYuO/nzEMPwYXuk4CD7pBOpEFlUYXdlRNG987ZTYcOkYLXCJlJpQ27ktmbZ5UdBOFEfw7xTjKDrYCek+VH2Z47lBSN9U89kVrqOZRabr2QIgRgRwRpXp4XkH2VV8KnJClOG2hnxn2YsYTDYDxqcYGWhHmYs+d9lRlA/ZyfxP2abqL9lHUG/ZTVj3mSDQ6aQe6lPpE6Yf1AKYDkIIgTPpB5QOQvJ0IDnVeWA5CPQb6VIuUDmteTA50VhwOXiBCDkL3toQeIGwWWvUaDnfUJhII5pYlL/80PSoWWxYN35XUAQ5IGzYWSDQf+my2mQ5CPRf6aPYxFlLeSQ5Krh0Od9QQBnRvkw5INC0WafqkBlS2qo4xg5ksAiBPDmEFE8uUnTmOK5sQjlXUCI5c3gCWSDQmvRNeK/wtXkyOW54AXkblAo5G7gyWX95s7AXWgpZTpREsARaHTCXPro56kb6OaBUhjlbeLpZcfw9aqksUfBflHgItoa5pIh+Flnw+KIZFxQ2WSU+khlNlNIZmQxuOfciSUQL2UFkg5SqGTPZfjmS8B/oEGz7PKD0uhk0NsFZ1j5gMOW5TSjE1GYZyj5HaFsimSz26Uk5qbr2GWSZF6SvvHMANDaZOUqWMEwS9rk5nUb5OWGZhVmZFsU5aumlObsWUobcmar5O3kbdrEZLJn/wj3WSRl1Wd9uipnryKa5ltndKZMpBWkLaV0Jodl7oE9JYU4Oua7ZeCmYabSpXtksaRDp2Ol2mT65TWkdya6ZlKCwYc6JuAlj1FHZ7nHRuf6Z4rDtWfG57TmJuTi+jlhzmS8wOdkZuWVwWbnyNjm5ZXB5uQiZf7lMCEW5TPbjOaW5zRngNoWwm7lVuY2QNbmDeitZtxlrWVVwTbkz2S25qYhtuXX5HbmDufs52ehIEVX5KOjbuedZbfmnMMO5j6SNuWO5nzQTuVX5U7leSkXus7lXYsUYC7mNuUJa+egruYN6oWSw6Bu5lbk3GdW5INnp2edQHgJshMiWUNn56DDZEZnnudkwPxmlude5O6i3uRnw97mxtui50JbPuUMU2LllcLi5M1mwmbm58JlNyCS5afkAeU3IQHllcCB5R8jzUMXwdLmQebp4Dtw1CLB5LLloIgh5sTBIeQHwXLmoeSZoAPAYeVgYWHkJ9FScNybYogHwK3BaGRoE6D5cmf4ZZHkB8BR5jChUeeKwSrm0eSq5ZTkMeYwoTHkB8Cx5Inlsea9YHHk0BVx5KRkxGQb5fHlW6QwFyRmOHA1Zonk66boUCpBRjmJ5uunKeZJ5MZlo2HwFwzlF2Y5Z32YexqkIZCjqeQBImnllNqh5OnlO6StwM1kGeU98RnkzWa3ZKXyLTKUUS7YpxoHpPcholI55795eGLG4M75Oee55ufmi5JhO5hQtmZ55eXnTuSxZfHjT2QP5v3mVukF5yUYheW78YXnWvpBB9lArmQBGehaxef2aNSg2lgdg6gjilHoIqXl/6kloN9n6+Fl5AWhnmRaUjgWqUIPpW1BFeZo5JXkI9GV51XnPmZV5SP69HDUItXlPNHkFm+gTpgu6q+mg+KJ0EDnteRW6wIFdeR6a4Fm9eYFC/XlCJLEwQ3nb1PBZINBjeVcaoCjulPtwT07h/G0ma3mYWbLai3lreSQ557SreWj0FDnfgD/pc3nbebQ5pxmaSF5YB3n3Rgj0x3nTVGw5R3kP4Bd5K749BWxZIjgDIk95KBlzeAPwT3l8WS95/JZyPt9MyP7y2F95KRoY/l4ef3njxH0sSjlSlF+0IPkb3oV5YSgiAQJ+TBksjrD5Q1DaWQj5JPBI+RAuCPl3ovV8kwxGLPdx6ny2OXr+9jl4eEgYVviE+XR4gUxohePG9oicuCPpMEgZEDGU1PkOdrT5tZSaGUHpYVgo1CE54DZhOYci7PngNpz5/nzc+VI+3Tl/8Pz5ZXGC+ayFKTnW6aL5UMbi+WVxYXZS+eJsknBpuIq5+Vlm2Yr5irnK+arImvllWTH5kRn28PR0etk1OQbZdTnGuWAiKRkf1vdxoCRmucdpJYn+uVb5QYkO2XsyztkO+dwpEbnO+VVp2Gk1af5ptpkMqQHZ3vnE6alxpOnAqeTpk/HfqUOpv2JjsiziRxKAaRxwqwVQ5hFIsmmO8WsQWWlhgoZx4blgUc+plvkI6djkFRAK6GjirgmO8S7ZZoWDcTcpLrmoCW65OOmWmXjp/tn2mU1pTpm6mfBpAblDYSC4JULCQfsQh3HJhcH5UfEu+VaF2Ok2hWmpnvkcwL65cql/KWPxfGndqQJproUgADUQuZCxaZiRGYmFcVbx6dAwSNJpHpTpaQypWyBDGdjgN5DThQfxMGlRhfqFMYWkdJYKIjx2+VvxhingWPsK4vFVKXTJdYXe2R65uOmvaRuFeYXW2eoJ0imWuY0pq4XYkSsRq2n/iHAJy4mY6fuFbvk+2XtpkqknhV75Z4VtiaGpxYX7wIo8M4nJYSjpmvr3hfRpNylPhSZpmYUNhZDpdoWnhea5frm22VeF/4XPYJ1pN2kgRRsJO4XxqQ9prvk7ae75OYXeuc2F3vkOaedpcTFbMuOgdFxdaWhFPIkYRfdpyAlbadaZuEXHhbmFn4VwRa2FwQlvqR2FH6ndhfupVOn0CQVWESZpgL6FULqcNMT6fHTXaVXxvlEyelmgFijabsaIh/Erqf/Jr6ntheFpzoU7qSmx3EXgqdTp6aLRIhJp1vGtJmF6xzj2vHWpxuwwouPS1yJNsQLpZqCKRaEJykX8aWTpVAl7qUWpPEWQqVrecDYQ3oJFVamnZjj4OJxiRcu49am7LLGQTamxKD9kqqaqaQpF66n/yeEJLoX2Rd2R7oWaRadA5ZEpkVCB32KCRVJpCMS4kEGFVfHpcjwJq6G5acFFKmnyRYLp5/H6mbaha74ZUdnsbmnoaQZpIhZGabWFEEX0Ra+FtoV+qcFpX4Vc8TqZjCnLhRbBCUVn4htQbOk0aZVFPIleabuFSfGWhXVFI2kMRV65h9DNRSxFxAlthdZFJOm2RZFpKbEeoEwg3qAMIDTAsUW8RTPhxqIZCrShgkUA3DJMloZwBM7ZkkB6CAkAjCw6yIDgfOkBYIuFCEUh2fuQr1gkCiT4t35ARelEiO67yNWFw0We2c+FOEUNRY2FdoWcBjioXDDTRSypLgBsqfDpxEVliPuQkgh/ctriqkZ2uQvQKSzJrpDWTrlDRemF2wBPaVBFHvkTaftwSMXkEbqFdmkXhROJvvldRgBgfzJywDPJU8ggqlZI4rKfKTcpgSnqKfjF6UkumWmJLPzhinhgUflARRdcTEgLsJdFQImRubcpeSkQyXDpBWnExeHqs9AVyIhJuAlUxTRIPMUfRfTFAsnAxXqFJyksxcaM19AYIQloBinSxRpINMUDcfzF8sXfyYrF34XMxRWJrMVJEkgIQMVSCVrFIRmHXLrFFKk6hbDpaynKxSbFqsWkxeXSSOzUaZTFmkjUxTbFfMV2xWb5PynCxf65osX+RSfimPn2KTtM3MU6xb7FXynjKbUpgcVOxayJszgMKLE864X+2cUwmMrpxR5p0cV0xWopCsWMxc1pTynW+QYJeBAdMBWFnCmZxSbCsKgoxWMphylxxY7FwdnWKUnF9+BFVlBWxqn0QhnFllhZxfsKesW5xQbF+cU++SHZxcWKZq3FIfEVxQNIVcWxKTHFtcWERVMpwcVXcrZAubDacpbFXsUyxVHF3cV+xXcpQsX1xcbFhoUuxVmgCuIEyD5FnsXA+NrFPsXrxVPF9sVbxTbZDcW7xSTFPIpcZChFVmlWxdY8vMXnxTnF3yl1xdfFO8X22XvFEjwhGanF2eknxdbFr8XAST3FH8UOhbNFG6k2RZ2FzCmfqWRBTkW/UVaxumETMilFhQzZhFZo3BATUBkJ7OntkVzpAVI2WOZF+WlLhRDF1qBvEAe6gOIUxRuAWzKIKXdpBynDadaFNpl/RQ1pN0gthVqZoMVtRURFxUWyEGQlVRAGiUmF1CXtKb1pdCV0RWNFv0XQRcwlniisJV/FRYVXhaOioQpXQSaFTwjo6XuFo0UMJeNF74X+2Y1pLUUFxYVpXQlfQbIsLUGnuQBJ3+BfMMolAsXfReDpYiVYxRIlwEBSJUrFP4WnKTwlUdrSwcYlAiU9aVrJASm9xRjFjCXiJRuFWiWGxUzFMiXPKU4l60FGJUBFJiU0JUDpFsn0JfWFPiXWJX4lLCUQJWxFSkXzRTAlUUXKqXHJCCUXCg4yGKnn5KepSWl6qeOFY4Wjhdgl8PFx0IjxdUBzhdipRCW3RXol7ZG8EjMhFEXzjGYl+sXeJeolHGlMRQRF2iUFhe1FJCVMMl6+SGmUJajpzSW0JYKptEVWmaIlh4XZhYxF+EWAwHYlgQmOhT9xpOmLRTJxeuJZJZ98leJVIa2hBSWSaUUlwqQb8cdJjuA8CfoAmZxKaXWgN0UOJcSJEFH/UcJJqEUjJVElpikWJe65Htm+2RolsyVlgPnFPSWcJb+FeoCbJZrgAOmURUIlYyWJqSIlaiVWJXhFgIjMRf3F3yWNKdclAEWSxXaF2IxmJeBFrrn1RVMlryUdJe8laYDQpeDFXCU2LJslb4BHxf7ZSKWjJUyAKKUZhWilLyVvhZilkKVdJQElmvGQJRFFyyWqRasls/EiaZ984+Lz4jpFI4VZyRhkByVARSFixyU8MBapS6kNcRZFXvHEJXileoCcpaYgAKX3JVRF8AlDRa0lkEVxJRClc8BzJfmFs2mExWTJHUW14s/GCuLwxcMlrNQDcdRFwOlYRU8lWYUYpdgpUKUOxdIlOqV9JepR/uDpYU0lxqVAiaalwKVMaZSlNYVHhRNF6qUfJbal9iWXhVcl6VFaGHKlrqXbhYqlmEXjJdhFliXopdSl1qV0pf3FiyUAKT2p0UUUCkDx7KXoUEISKhL7SIlpw4WWRrylKmgThWUloYWVJblFlTL5RbBpqClBpUXFhRw5pctIYaVbhcBJg0U1xTElB4VUpY1FH4WJpQGlBMWkaUEl1vliXN9Y4uINpXeF8qWeadVF3mnmpaolsSXtJQmlGqXaJUEJrfEdqUylC0UspVEJNRDZcZmlBEHc0ZkS3KUFpQapeyW9RROx5SX9jHyc5aWzCmKlNSWXJScJO6VYKXcl4aXASe6ljyXTpe2l3qXTJb6l9oXdJVqlfaX2pVKl0YBogPqJC2IupU2ldUlPpRtpU6WopZMlHaVMJV2l86X0pb0lf6Vc0QBlmgqjpQ+loGWRpTRFIKUTJWClcaWdpZ0lcGU4pdGFfSV/UZJgkfLAZUu4r0lgZRjpEGUUpVBlb6VWpU2FBGU9pYElv6U/Jf+lbJHo7I2lFGU8yVRlXHE0ZejFKqWzpYxl/qVXxYGl/aUSiTGA18EAJcBFY6VupRhlZqXRpRalmMVqpZ+l8GXJpRFpa6WAklHRg6lxRdkAEtFi4B/we6VFpcUl/KUZKYKlXOlnpSKlcBChRYVF2gl9JQMShPKTEqhlIGWvSRvFMaXPJfRl8aXCZdilzGXrcRwluKVsZWog+mWvnIalMmVoZa5lDGn8ZbHAXqWfRQxlMEU2paJlRsXiZaXx+mUCMS9Fm4XcZXC4+UnkpQJlMWV1aTMltKVMZYllLGVFRYFlUQAS0eiyFfHkZcilUWWIIHllnrlvJYVlImXEyWJlrGWNKQ5l4qAg3NVlpKXgZYplL6UvhbhlMGX4Zc1ltCmtZaVl7WUVZQJcjSX3pS5l5KmRZX1lkGU4ZdBlviXDZT5lxWUMpcklc0VOhauln6lAkusl89Hj0ZmJKUWHpQCkpmWyiSel2OCWZWcl3cAXJTWlu3HJ0VyS0mUZcOFlc2XvxVtJbSXgpQVlfqVrZS1lvaXOmcllV8EPZZtAFymIpYClHiVDRTll0WV0ZbFlXmXxZd2l62UIZWVl3xKEUSvi6WUkpQ8lvWVYZe5llqWw5TRpsEWEZZKlSOXJ0b7iZcWg5bJl0smTpQtltGVLZZ5leGVYpfMlJWV2ZYhl5WUL0csQR6XEpWDlFOUQ5bVlH2WDZStl9OUzxURlzOXI5fIAHtpPZRllNWVU5bll0OX5ZR+l+OW+ZYulVkVQJaklnEVppewAcpL7ZTvRcoltMnCpSQme9qlpXCEZRcu4nmHHyJmCCPHXZSsgt2UA5SfJAwk65ell/iVApc+li2UzpZ9lE0WkUNvoDOV+ZXNpQuVlZWERL9Hi5Q7l4OU45Z6lMuUNZTSl7uWLGJ7liuXhRQqpgClq5UtiwmkehSMyGKCP8rrlhSXDUAblOcmlJfjAZI6I8c6M56XQaZelamk+5cLpKeV3pXaFgeURpW5lSmWqpQVlEeWkUJ7lXyUBZcLpETJXMgHliSXoRfJl7vnY5cpldeVXCg3lSSVLpexF0CWq5RklFAp6AJrlRAqUGQ0xRmWdKGvxCNDFpYGy98gVJRYoVmVE4VWlEqWySUNhwkHsQRIoiiWgSCmF1eVyyb5lTeXRhScJJiWyYLaSlYVd4HSljuW5KYTJSaWMpbHlqaVj5d1crgqT5TlB2QpHZTsl1vH3DAelgYXZ5exxXbiI8eXcBeXKaUXl1qk6pdYpnKVGIK0pMXHuJfsKLaUf8aH5wHYuVvnMAPDoFTDwqjSo+Jbw3jBvWDqoUxmd+NdYDnADGU5wm+w2RHcunbgThojYcdBhxuLEBOqn0FrKdPlJKCwcv4i7XHT5z0hqmEw2qvySWhp+eBXw1NuKsZpPFGqswhWoOGR8vBVgjgIVwyjo1PwVrnycFYF4F9m1lCwVNWwi8JF8OhAk8OpGCVB41NQVEyq0FUrkz/CDnPpYsnlEFSgCMASY8KpGRo4ZCFC03oDY9jgVWBU6RmHk8PirgKb5m8W/Za1F3uVLhdAV7wYz0XAV0WjTsUgVBCkoFbVGlIC2Fd/ueAV4FU72dhV3+c2UphW8uFaIBhVq/misb7Q6Fcc+ehWotPQVPz5aFas0aKxSvgYVCzTyFRj+ihXyeIIVZNSyFbh6EhViFY4VlRVZtCIVGHoVFYmICzT1Fawor1j5FT02sjlFFWdar/TerHkV6RW0FTjYTBWkIikV81hpFZNwZBUGLkYVtAgxFeF5ZhXhFQIWd+hRFYmJVhXoPpgVouQrFU2UThUYFQ4VLhWCxW4VG2VD5Skl22UwJVJx4wC+ACEApIAhANmxMUCOAEoguyD7IM6KYACuiqEA14BTcXogBACqQCbB7ADAgACAMukY8dwAHgAscXlATIBkzIcxJFC0AExQKgCYAIRgkJUDYFGxqABewblxqABfgN+kS2I6kJEECeUHAPrQbFCF8ctiBwBbQFiVeaBq2npQeaDzIc4VZlCF8Y9AbiHqUHmgNCGTYmSVX6kHALIo+JWqqQkAw9B0lUJpDJVvZHSVYKkr4Kb5RFDRCQcAvMx0lSApDJW8gPiVlOkJANbCdJW33LiVopV0lfAlQVCcld44IAA0CTBAvJWF8ctFq0XrRbiVDjh0lf+RTFCClUqVvYW4lQeg+JVrJUFQkpWGlWraqgBqlT2F8yEqwKaVbiGXSKaVNJWslYaV2mXFAKaVK9EqMIBYupXxyRaVfJWUChiVvcxBAOpABAAuAG4AvKADCUFQCQDoSPfgllDcUF/QfNCA4J8xhbGrqaAAP0BIYEQAiIChANgAXQClAJAA5WDYAI9AfAAAAPRzIdgAKAAQAIWVFJVllcIA2ACIAHAAjgCkIIiAagCxQACAaUCXoZ8VkgDhIZIAj0B7oSnQIzEhUC6gvHEGwQCA8ADjwPCAAYRoAPhonsHwACwgmIAQAB5AS9BVlYVA4wBN4pmV2ZW5lf4A+ZUrlUWVpZXllZWV1ZUGALWV9ZWNlc2VrZXtlScgg+TAgD2V2iD9lQ0Ag5V9QMOVBUCpQOOVk5XIwNOVuESzlfOVmQBLldiAK5UwwZrAG5U5lXmVBZU5lcWVZZVGABWVu5U1ldQhp5XBAOeVKgBtlR2V15XdlXshvZXwABqgaAAEACHB8ADcIMSKGoLwAHKgiRyzldqQFcF4AOOVq+C+IN+VVyBjsdZgIQChweMAIODAVVuVjgA7ldWV+5VQVYeV4FXHlXBVDZUIVS2VSFWXlZ2VIAA3lehVd5VYVThV2IB4VQRVQNBEVSRVFFVkVbPBFFWuCnoCNFUGwZWx9FUbweMAA2BIYMCAwID0oYyhzKGouMCAHqCowQfAMMH1EnpVkgDAgIGhwaFkAKGh4aGRodGhZACxoZIALqCfQNwgbkByoAwgZ6FBoSGhYaERoVGhTCCP6K5V8AAeQC6g3CCUwStFbkCTwOMAwJLWVV2V6uXbEWQAB6H0AEehJ6FnoRehg+TjwMQALCBgAPCA5WAjMWlV45WaxLOVRcDlYDFAAIC4VRFV4SDjAPUQSGC1VdgALqCpQGhg6qDYAEwgYQAQADKg2ICxscCA3zHsAJsx2zG7MfsxhzFGAMcx0h7VgMCAQ1U7MXsxBzHiMBNVpzEwwRPliVWiVZIA3kCbYZIA3CB4VZ9Au4jqABqg21XjwF9K5VWVVYbB0lXeoHlAVQCHlW5ALgDLVbxgq1U3lXGQp+F5oJhV2FW4VfhVJcCEVcRVSgCkVT0gs5WqVXkg6lV0Vf4A2lXdlcxVvvH6Vd2VkeHAgH2VklXvVbJV6xDyVT9VilV/VSpVVFUGAEDVmlUg1YxV3ZW6VRDVNlWSACfhMNWvVVJVMlWfVXJV31X0AL9V5FWUVWpVFFUuwRpVWlU41ZThVlVhKZZgTmBEACWV3CBvFS4AL7EdVfZg9QluiklVS2Iy0SIRWdGSADUQHkA0wPAAz0AsIPAAG2FeQPiAstX4gBqgLqDwAHBRIhHjwGmsJ1XhAGdVy1UJVfjVwtWvMe8xnzEDVSAALqA0wLC64VUMIOPA70BMIHhVbzGxoeMAU1UPVZIAxRFIUKURXgDAgAZAZRHwADTADCAiEXKgBAD5QLiAntVgAI/oK4DnIAbBcAAwwZQAmHElwGAAKAC7zC6gzVWVlYiAuIDYAAAAFDBRgtU5lbogOFX81UQAnpAllTpAqUB+QNiAjgAllR0AVyAAAJSQ1clVQjG6UXsRBxHDkW7VxABzlQVVK5WYVVjAp6Ea1eOVwdUxYGVVXsHO1UBVhtVrVZThagCD5PbV3NVaQHhVXoCzlQAA6kkA/1Xa1cPVkgDyMJhxTVUeQNwgHVVdVT1VfVWSAGbVM1W7MdvVKNDqALZg0h7qAKZV21VMIBqgj0DcIErVWzGzVafVk1gX1ZrIjMDO1XjVhfH11SAA9rGOsc6xoQCuse6xnrGxsfUJvrH4qSjB/tWPQAAAmscxLCB31TQgDCCPQPiA9rH4gOPAj0CfQDmKztWs1Q0pZWDR1YXVDmBOYDmVmdUNlbogVyCVsYiAUACOAEWV/kAxYIWx1DWkgNgACIA6QOpA1DUhwbAA2AAXVQ2V67G8cQAAhHXVBNUN1bBRA5EiMewAuVU2YPlVhVXDMR5ABUBSAMHA6tUiNblV0WBVAEPVsdUG1YXxbkAV1XCAWkDOsXuxBDW51QUAWdU51Y5gVyDYAPnVUgCF1cXVpdV0NRXVVdXeALXVP9XaUTsRelHi1WI17dWSNV3VMjVwgPI1cFF6UUo1g9WccJXB4wCqAJhxmjWyNTo1IcHYgPo1JjU5lWQARjUC1TE1ZjUF1T2RVjW0NeXVldXV1aEAAjXC1U41vjWiNSAA4jUd1VI14VWyNT41TdX+NSo1gTVr1ewAvxCb1VFgMWDRNUQ1jjUy0TVRrdVuNRI1ndVFVV41cjX/QAo1rND91co1qjXBNfdVvvEtVdpAKADtVRqgpIAuAE5AxDXGNUQ1STUWNSk18IAl1Wk19DV2NShQWTXNNY3VstGuNQU17jWdNdI1pTW9NXBRINEVNUM1hNUZlb7xAABayIB5QJWxjTWmNZ+cZtW5NcDR+TWFNR41XTXHNUFAfTVnNQPVlTVkwEE1hNXrlTc1dzWOAA818zWmNbmQLzUy0ZnRbTX7NR01xTXdNWU1stHnNVU1MMEawJhxP9UH0cCATCDjwPAAj0D8gO9VXID/VdEIQLU1NeDV39WCNSAAOLWSAHi1BLVEtdJV3CAktWjVkuzktSAAH2BFKXg1BABgAI81xDWkNeQ1lDXUNTogZdX0NUw1FjXMNWAArDXYAOw1nDV6wYWxF7H8Nds1wjX9NXs1HzWHNSU13jUnNYo1/zVD1eFVkVX91YJxcqAI4AEA2sFGQNGIKJUYla8w6JX/UDqVSpU4lUFQpJVKlcWVBwBElUbxpMA2lRSVBwBUldQhGJWeteoQjJVslTqQntBMlUMgZtD4ldyV9IJCleoQBpV8ldKVQVCylUqVKpWKlQGV6hA1uLqVOpDvfLqVQyCvBrqVVpWJtQGVdpWxtYXxL1EYlSaVupUulTaVkdEYlbSVhpVelWgIppV+lVW1E+X/UMGV/vEWtcKVNkA2leKVBQD+lYXx8pVMUCm16pWfQCtFa0VptYWq0bH+APAA5xVSANmxbkDZsaUAOsA66C/IbbFe5FoGAIEusKMuw3DVLptUO7UvtoXw7pxI7GoU34LlvnEEVcIJxGhqy7VwejQkZs5XtafZgFR0Wme1fbxA/oC4R7WlNOtkQBR7tbh0H7XN1lu1OoggAB5AC7WfAEmMR0Srte/GN7X/BNJUT7VYtCe1NVRbtVm0r1ADVGyYliawUPmqUHWNsnwZD7Udvm+1z7XKNuu1YCKjLjzsJ7X3tRc6vxIXtd68sFARWvB1UhkbUDAO0Zk7tdh2tHX7ta62Riw3ta4iO7V5DJR1jblsmJj4QP7cdWF0b1mvUGDwzUgbtTLU0ZlHtfl2bdnrZL+1dwjzMGx1MnWWJoR1OESildrBZwrNAIu1YyBZoS5WiHUUeDp1JHU6PnEEiLBKdfvesnXftU9o8XjrZO+15nXevu6Qr2bn1KfqVMjhaBEcWHVG8CB1cnWnMBm0d7XbcBx1VGymdaMVtnUKdS3COnWBdRR1+arzpZh1pHUE6NGZxnWCdXQiuHUQbEp1+nUJLFx1FCaUdfjsHnVh5MF1xHhMdd51AXXZdXpC2sGPQEB1mnVrtbZ1N+TIdV7wV7UlnOTYWJXeiKJ16OR+dfoWeXWbtY1147jtZA11inWfAml2hiYvtYF20ZlldSb4B7Vg8AN1OPmAVD11eHXn1P1GiHUGdXp1cvweddV1WdkidX6OzUgmldrBhaC5cRp1wcgrdalxa7WfAnxKFXVWdWvaRvB3tbV1ONxHdd6w1HXc3ke1cHWydf+1r0DFdT6oeXVgdWK8+HXEdjl1+EV0eEx1WJVzwFMUB7Xbtc1191R/df+170APdUaa4XLPdWIWS3XUhpd1dXXWxAd1/7WfQA91F3Xg9Vp1AZmOdYDEyPUodfJ1qEZedRY5LnXhdQ0w1nXPUGyYbrRDdaN1xJ7HZmT1XmyWdWZ1R3XGWCEEcHRddY+1GHVtdbe1MPWsEBe1N3WWJie1vCxudbl19XUQdXXwyUib6TT1nbk8dXr+Y3X89flawvX+tLB1qEbnteSOmPXH+lGxVzWgAJt1YnWgdaj1V3UJxCF18XXKdbj1OFDo9cpMqHWPwll12qYpdQV6JvXpdT1GB2AudQFo73VtMPZ1JnWKdU71NnXlpEl1r7WXupb1aXVOnNB1MYhm9fRs7PUSdVi4BvX09QJ1rnV+9XrkOvXYdWEi/7U5iht1j6Cu9RD1AZnrZIa6B3WpdWF1HXV9tfGQ75qh9QBw0nU49X+12sFCcWr1wHWGdTt178Yxdcd17PWC9Vz12fXKwmPsefVVdYX1rXX59ZmQsLk66KtwF7Xb/E9o/HWQdST4fHX/tSM1pfUqgCB1N2DJ9YO54vX6BCt1/3UbtQT1sIJ/6i11liYHtT506fXe9Zn1foARdWX+hnXjdRBs3fVg8FX14qrmIlv1iL4ZdUwI13W+dS71vXXV9bd12sF41SP1W3Wj6BX1L3V7dSmEa/WH0D+1LfXc9WV1dfVq5CAAILUP9Rr14/Va9cuqaHW29RT1bzBW9Zf19fVG9fEMfPVi9eH1OfVutJ/1WXiWdf+190EJ9aiAUPXP9ZD1PnWqeBJ1rwhJWpFIp3WTdZ517PWkDUdZvfX/tSwAoPUN9a/yIA01nCQOqfWuIt31v/VS9SnqefW19d+AbnX/tUXAtA379TgNKfUgdbr1uHoSdWwNWwGu9Uv1yvWSADQgSPXCgAwNVfXz9ah1moRZ9YFWT/Vf9YB0P/Xy9dtwrA0h/p31s/X5WgN1ffWn9Tb1XA12VK312A2oON31zHUkDoL1UnXt9b71LPVZiOoNN/VY9fN10A279e3skfVnddd+6PWHdTfkefUUDSlsRfVRsWXAmA0cwM31E/Ww9dD1Fg14DUr1/g0h9ez1I3UaDX/14SDhDXfADA2WDa4NXvBZDfENGHqjLiINbzDY9RHQHvV6DfyqR/V79R+1CQ3W9f1GyQ3mDVf1eHXB9aUNf9gM9QV6xQ3oddT8zfXZDQYNMQ0J4P+1saHpDfINpXUoDVH1TnUD9Xh1zA3udX4+7/Xe5C4NgfWt9Qx1zPXU/MH14b7g/v519XVNDVX5U/Vg9ZYmZg2s9ex1APU+DX7kug3E9foN6RUF9SUNSt4uDXkNbQ3uDVINng3xDNUNfXUdsP+1cqD8DZ/1UQ3gDTo+Mw2vdeINTXVz9aoN/7VaoOENtgRCdYINk/WIDQv18RbKDU14xHWndcwNfw1kdYr1qg169b/1/7XsACCN4w332BD12sEsIHINFXXgjdENiI2/DSkNp3VZDfb15SLHZiMN1ShfdWSVhPV09SiNVI1E9fEN/7Wj1YANUXWa9Wu103Vpdnn1uQ2MjRCN/fUr9TkNeA37DcMBq/Yo7Bb1/vW0dZx1syqgDRmqpA3NDRSNDiKH9XQNDw1u9QR1TPUx9WMNMI1LDaCwQo3EjTz1xI3kjYGkTg17DXqMsfXawZPAgw1AwJkNIo38jUSNKQ1zde11Pw3cjY8NqI3PDYiwdQ2gjXF1TI0MjdyNao1reDb1ro35dQ4iQQ32iDP17A0Ldat1UbEMILQNMvWEjSSNn3WUjVKNgj40jXpCdI1fDQ5UvI12jT8NfI0ujZqN9w3/tXiA7I0CDT9xa7VhjR0Neo3bdR4NqLRy9d0NkY2ODdT8Zo12DVsNkI1CjT0NMo1CIoaNEvUQDbMN85z+jU6NAtom9aF1GartjRn1GaqcDcL1FnWZkH/1uiC0DTF1nw2v9eT1S3qLDTWNtw1+Pv6N/7VnMZiNY/UJjbANjo0GetWN9w2DjS6Em/VyjZPWEY149ZF1+/UBjeeNt40c9e0+znWRdVD1I40W7H4NJ426jWoN9epN9WINa42kInWNlY02DYe1XvX/DflaL42tjf31RvXGDZ2NahTGjTeNOg0Htdw29HV1jfP1+42FjdrBVAC0DZENto2HDa/1QE2fjQ2N9Y0IDf31kw2ETaMNsE05jSd12sE1EPONSfUMDeX1B41R5HMNUI31wgUN3zjC9fYN75rwDaBNvQ3rehf13Q3/tbdVO40k9QmNxo0DjesNCcxNDWSNdo0wjWKNi/VPjUt6DE16jpL1641DjZKN5401DTdmBY19jUZ12k2vda+NnvXaje0NJo3U/EpN8w3c9QBN9o2JjYBN/7WT0MJNnfWiTXaN4k08TWiNGY3GjQqNCE0sdeb1so1t9aqOXXVfjZaG/k0fjRKNPk06jSGNcHpQDQJN2sEEAFhNbE2fDcaNuY1OTf5N0k3NdTcNAo3ddWRNHI1GaCcN8/V5jdmNhw1j9X/11OGYjckN8U2UTUH1cQ2AjRmN3Y34DeR1wU0CTRmNFY2ZjR2NQ3hwjdrBykDpgJ8ApU0MDWaNpE2TcCcN5k2VdWxNRE0pjUh13E37DasNRxZNTeBNNHWpjTz1+RX7NkgNck1tzAx1LU21TY+NgZhtjZeN6U1Qdg71Do3eTV2Nlk3OTTsNEvhBTbNNyNpcdf+1KABxjSJNZY3vxquNI02A9V5NgE2ZTXhNEE0YWrZ10E2SeOJ1Mk1sdfhNIU1djVoNyk29jc4N/Y1nTUUNdw13jeONzSx/TYz1dvWgzbpN8M0zTZANPvXxDjh1qk0ZtONNCM0GjUDNg01/9ZvA7I1BDWVNhw2JTYcNm41uTXaNO/WeTSQOHk0wdeKNB006Gb+NwM2KTUeNCk0TtS6gcg1LjXdNL3UJTflNAI0/DfqNrU3fgkLUt03HjRbeDk0eDf+1AOHWjY5NJM18zXD1J3UZjV6NVk0PTaKNp3V1DWlN+00nTX/1JGCDDZYNxM31dVBNnjBEDbMa2sGH0fZNYimfDWFNzM27vJFNeM0pTfV1x03WTZtNRxYrDY2NbzS4zVZNZk1WTU1NfU0ozWANeE3/tScA7I2CzZ8NCI09jUt6XQ1szWqV+02azc7NLY39TYhN7s2cTcosTfXDTfbN2sHwALRNvXVhzf5U7PUxdRnNUbFAgCVNVPVWzXbNJk16jQH1Ks2ezbmNA00VzWtN5E1fTWY4n03vTVGNDc0Epjb1bs0MzSnNy40h6VXNTs3WzXeN/7WbdQ/1SvUJjVzNNs3LTbwsefXezVTNV43fDXn18Y0RzRO1NIDsjUvNBs35WqTN/M2Kzd44Gk1/jXvNSY2hjcZNsk1XDWDNKk2H/hcN0c3UzU2cw42ZTQqN/7WztRbNnlBlzajNeM3QzbtNyY0TTQDNj8Kszc1NtY30zVfNEk0S2sONJA3lzX7NSo1SWuz1NU1vzUAtBE3ETVHUHE2tzVYNf3WZTatN/83yTQ+NFBmCzetNFBmDzaqN/7UJQOyNC409Tej1vc09zZLNjU3GTU7Nqs1WTW7NYfWuzT510Q20CBf1T01ScP+14NVrzQxNL80b9WnNWrbVzRcN8/XQLVlN7c1GDUgtgY1hFlON6o2bNMaNb02Jzc9N9c3nDQ4Nj01pjUh1gQ1gLVjNwY1ozSBNFQ27tS3NEg3X9drNcM2RdWON6/XyjbDN5011LLfNWLSezSfNci00zeYtLk3hTU3N2s3/tf/g+I3YTWu1S80wLR/11nWuaCf1cC2jTWbUX7W4eunNjA2JtJ7NUk0ZjWhN3i2PNAAtCi2wLexNrQ07TdT1M41iLYAtji2nDeUNLE1ujaINnPWMTV/NYs3+LdoNvo0pDCT1pTRU9ZPNuHQVLUtNtPXXfogt880OVFjNvs0/jXktUU1Rsea16nVdTaXN9E1VzSYtGS0QLTHNzs1bzQrN+c0FjSyN2sGs1Zwt1Y2fDTQttM2piHXNti39LX/N8C2UDZMOyS1LUEN17c2FTdfNOS0XzUotcc3YLXHN1s3z9ZotQA33jfBN+i14daItDS1kLe/N382ZddKNrHVn9dYtl80dzf1GXc0DLZlNc83rLUiNFBlmjcjNWs3mjWMNHy3xLXstufXs9dgtMS2kGGAN4C2ZjYZNVXoGLfpN7o04LYjNxi3bTQfNny0WLZpNf/UG1VMt6g3xTXXNPw1RzV7NVc2wrU1Nsi1FLb91tUTIrYYtly179ZstRi3b9eit0K0qDWeNKi2GNlAtQM1xzV3NuU12jdstKy2xdfK09C0mDe8tlM3MrSCtefU0LUbNWK3qvnVNpi1Uda31py0IzfeN983awVAAN00SzdwtU0bgzXvNL00YzT2aRxaCzUwt+Q3lhmEtU80nrCgtCS1MLaAtr82grRAtOM2vLbXNSc0R9U4NMi3vjQKtzc3u9Wktyq13zQ4trC03zepNvk3X9ufN9q3LzQZN9y3/tVmhIc3TLQwNNC1OrfItsK0yLfUtGS3jLVGx8JWdLaiA3Y0bzbxN7c3kzbvNzs1zLf6tME3kLZUth43MTQPNx81WLf7No42zdfKtrk35rXgtfS1szcWttS3rBDqtWU23LfiIxK2LLVdBEtaYrYCIwg2SzdrBScGYjcQta7UPTXHNNC1GDad1E83ZMGcNLy1KLfSNht7GTTL1gy3uTX6tQa2rLdLe3s2qrVGxpvHq9UcN482kLfvNLK0peHmtAZmzrcst1a3YbCENK7EarZbNDA14LT8Nxy1VTQ2t6i3eDZCt/C2LrbQthK1YzW6t6M0/LUitHq06Te3Nha1hLS2tC61+TSGt7K2drdetxa3/tV0QIc1ZdWHNg62lrYb1oS3nrUstwy0FPvOt8y3OrYItXK1WTV0Nqa1RsQQAcJXwABehuPHgNdsAuiBbIDQA+IBJweYAQAAA"))
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+/* Utility functions */
+
+var storagePrefix = 'KiCad_HTML_BOM__' + pcbdata.metadata.title + '__' +
+  pcbdata.metadata.revision + '__#';
+var storage;
+
+function initStorage(key) {
+  try {
+    window.localStorage.getItem("blank");
+    storage = window.localStorage;
+  } catch (e) {
+    // localStorage not available
+  }
+  if (!storage) {
+    try {
+      window.sessionStorage.getItem("blank");
+      storage = window.sessionStorage;
+    } catch (e) {
+      // sessionStorage also not available
+    }
+  }
+}
+
+function readStorage(key) {
+  if (storage) {
+    return storage.getItem(storagePrefix + key);
+  } else {
+    return null;
+  }
+}
+
+function writeStorage(key, value) {
+  if (storage) {
+    storage.setItem(storagePrefix + key, value);
+  }
+}
+
+function fancyDblClickHandler(el, onsingle, ondouble) {
+  return function() {
+    if (el.getAttribute("data-dblclick") == null) {
+      el.setAttribute("data-dblclick", 1);
+      setTimeout(function() {
+        if (el.getAttribute("data-dblclick") == 1) {
+          onsingle();
+        }
+        el.removeAttribute("data-dblclick");
+      }, 200);
+    } else {
+      el.removeAttribute("data-dblclick");
+      ondouble();
+    }
+  }
+}
+
+function smoothScrollToRow(rowid) {
+  document.getElementById(rowid).scrollIntoView({
+    behavior: "smooth",
+    block: "center",
+    inline: "nearest"
+  });
+}
+
+function focusInputField(input) {
+  input.scrollIntoView(false);
+  input.focus();
+  input.select();
+}
+
+function copyToClipboard() {
+  var text = '';
+  for (var node of bomhead.childNodes[0].childNodes) {
+    if (node.firstChild) {
+      text = text + node.firstChild.nodeValue;
+    }
+    if (node != bomhead.childNodes[0].lastChild) {
+      text += '\t';
+    }
+  }
+  text += '\n';
+  for (var row of bombody.childNodes) {
+    for (var cell of row.childNodes) {
+      for (var node of cell.childNodes) {
+        if (node.nodeName == "INPUT") {
+          if (node.checked) {
+            text = text + '✓';
+          }
+        } else if (node.nodeName == "MARK") {
+          text = text + node.firstChild.nodeValue;
+        } else {
+          text = text + node.nodeValue;
+        }
+      }
+      if (cell != row.lastChild) {
+        text += '\t';
+      }
+    }
+    text += '\n';
+  }
+  var textArea = document.createElement("textarea");
+  textArea.classList.add('clipboard-temp');
+  textArea.value = text;
+
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    if (document.execCommand('copy')) {
+      console.log('Bom copied to clipboard.');
+    }
+  } catch (err) {
+    console.log('Can not copy to clipboard.');
+  }
+
+  document.body.removeChild(textArea);
+}
+
+function removeGutterNode(node) {
+  for (var i = 0; i < node.childNodes.length; i++) {
+    if (node.childNodes[i].classList &&
+      node.childNodes[i].classList.contains("gutter")) {
+      node.removeChild(node.childNodes[i]);
+      break;
+    }
+  }
+}
+
+function cleanGutters() {
+  removeGutterNode(document.getElementById("bot"));
+  removeGutterNode(document.getElementById("canvasdiv"));
+}
+
+var units = {
+  prefixes: {
+    giga: ["G", "g", "giga", "Giga", "GIGA"],
+    mega: ["M", "mega", "Mega", "MEGA"],
+    kilo: ["K", "k", "kilo", "Kilo", "KILO"],
+    milli: ["m", "milli", "Milli", "MILLI"],
+    micro: ["U", "u", "micro", "Micro", "MICRO", "μ", "µ"], // different utf8 μ
+    nano: ["N", "n", "nano", "Nano", "NANO"],
+    pico: ["P", "p", "pico", "Pico", "PICO"],
+  },
+  unitsShort: ["R", "r", "Ω", "F", "f", "H", "h"],
+  unitsLong: [
+    "OHM", "Ohm", "ohm", "ohms",
+    "FARAD", "Farad", "farad",
+    "HENRY", "Henry", "henry"
+  ],
+  getMultiplier: function(s) {
+    if (this.prefixes.giga.includes(s)) return 1e9;
+    if (this.prefixes.mega.includes(s)) return 1e6;
+    if (this.prefixes.kilo.includes(s)) return 1e3;
+    if (this.prefixes.milli.includes(s)) return 1e-3;
+    if (this.prefixes.micro.includes(s)) return 1e-6;
+    if (this.prefixes.nano.includes(s)) return 1e-9;
+    if (this.prefixes.pico.includes(s)) return 1e-12;
+    return 1;
+  },
+  valueRegex: null,
+}
+
+function initUtils() {
+  var allPrefixes = units.prefixes.giga
+    .concat(units.prefixes.mega)
+    .concat(units.prefixes.kilo)
+    .concat(units.prefixes.milli)
+    .concat(units.prefixes.micro)
+    .concat(units.prefixes.nano)
+    .concat(units.prefixes.pico);
+  var allUnits = units.unitsShort.concat(units.unitsLong);
+  units.valueRegex = new RegExp("^([0-9\.]+)" +
+    "\\s*(" + allPrefixes.join("|") + ")?" +
+    "(" + allUnits.join("|") + ")?" +
+    "(\\b.*)?$", "");
+  units.valueAltRegex = new RegExp("^([0-9]*)" +
+    "(" + units.unitsShort.join("|") + ")?" +
+    "([GgMmKkUuNnPp])?" +
+    "([0-9]*)" +
+    "(\\b.*)?$", "");
+  if (config.fields.includes("Value")) {
+    var index = config.fields.indexOf("Value");
+    pcbdata.bom["parsedValues"] = {};
+    for (var id in pcbdata.bom.fields) {
+      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index])
+    }
+  }
+}
+
+function parseValue(val, ref) {
+  var inferUnit = (unit, ref) => {
+    if (unit) {
+      unit = unit.toLowerCase();
+      if (unit == 'Ω' || unit == "ohm" || unit == "ohms") {
+        unit = 'r';
+      }
+      unit = unit[0];
+    } else {
+      ref = /^([a-z]+)\d+$/i.exec(ref);
+      if (ref) {
+        ref = ref[1].toLowerCase();
+        if (ref == "c") unit = 'f';
+        else if (ref == "l") unit = 'h';
+        else if (ref == "r" || ref == "rv") unit = 'r';
+        else unit = null;
+      }
+    }
+    return unit;
+  };
+  val = val.replace(/,/g, "");
+  var match = units.valueRegex.exec(val);
+  var unit;
+  if (match) {
+    val = parseFloat(match[1]);
+    if (match[2]) {
+      val = val * units.getMultiplier(match[2]);
+    }
+    unit = inferUnit(match[3], ref);
+    if (!unit) return null;
+    else return {
+      val: val,
+      unit: unit,
+      extra: match[4],
+    }
+  }
+  match = units.valueAltRegex.exec(val);
+  if (match && (match[1] || match[4])) {
+    val = parseFloat(match[1] + "." + match[4]);
+    if (match[3]) {
+      val = val * units.getMultiplier(match[3]);
+    }
+    unit = inferUnit(match[2], ref);
+    if (!unit) return null;
+    else return {
+      val: val,
+      unit: unit,
+      extra: match[5],
+    }
+  }
+  return null;
+}
+
+function valueCompare(a, b, stra, strb) {
+  if (a === null && b === null) {
+    // Failed to parse both values, compare them as strings.
+    if (stra != strb) return stra > strb ? 1 : -1;
+    else return 0;
+  } else if (a === null) {
+    return 1;
+  } else if (b === null) {
+    return -1;
+  } else {
+    if (a.unit != b.unit) return a.unit > b.unit ? 1 : -1;
+    else if (a.val != b.val) return a.val > b.val ? 1 : -1;
+    else if (a.extra != b.extra) return a.extra > b.extra ? 1 : -1;
+    else return 0;
+  }
+}
+
+function validateSaveImgDimension(element) {
+  var valid = false;
+  var intValue = 0;
+  if (/^[1-9]\d*$/.test(element.value)) {
+    intValue = parseInt(element.value);
+    if (intValue <= 16000) {
+      valid = true;
+    }
+  }
+  if (valid) {
+    element.classList.remove("invalid");
+  } else {
+    element.classList.add("invalid");
+  }
+  return intValue;
+}
+
+function saveImage(layer) {
+  var width = validateSaveImgDimension(document.getElementById("render-save-width"));
+  var height = validateSaveImgDimension(document.getElementById("render-save-height"));
+  var bgcolor = null;
+  if (!document.getElementById("render-save-transparent").checked) {
+    var style = getComputedStyle(topmostdiv);
+    bgcolor = style.getPropertyValue("background-color");
+  }
+  if (!width || !height) return;
+
+  // Prepare image
+  var canvas = document.createElement("canvas");
+  var layerdict = {
+    transform: {
+      x: 0,
+      y: 0,
+      s: 1,
+      panx: 0,
+      pany: 0,
+      zoom: 1,
+    },
+    bg: canvas,
+    fab: canvas,
+    silk: canvas,
+    highlight: canvas,
+    layer: layer,
+  }
+  // Do the rendering
+  recalcLayerScale(layerdict, width, height);
+  prepareLayer(layerdict);
+  clearCanvas(canvas, bgcolor);
+  drawBackground(layerdict, false);
+  drawHighlightsOnLayer(layerdict, false);
+
+  // Save image
+  var imgdata = canvas.toDataURL("image/png");
+
+  var filename = pcbdata.metadata.title;
+  if (pcbdata.metadata.revision) {
+    filename += `.${pcbdata.metadata.revision}`;
+  }
+  filename += `.${layer}.png`;
+  saveFile(filename, dataURLtoBlob(imgdata));
+}
+
+function saveSettings() {
+  var data = {
+    type: "InteractiveHtmlBom settings",
+    version: 1,
+    pcbmetadata: pcbdata.metadata,
+    settings: settings,
+  }
+  var blob = new Blob([JSON.stringify(data, null, 4)], {
+    type: "application/json"
+  });
+  saveFile(`${pcbdata.metadata.title}.settings.json`, blob);
+}
+
+function loadSettings() {
+  var input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".settings.json";
+  input.onchange = function(e) {
+    var file = e.target.files[0];
+    var reader = new FileReader();
+    reader.onload = readerEvent => {
+      var content = readerEvent.target.result;
+      var newSettings;
+      try {
+        newSettings = JSON.parse(content);
+      } catch (e) {
+        alert("Selected file is not InteractiveHtmlBom settings file.");
+        return;
+      }
+      if (newSettings.type != "InteractiveHtmlBom settings") {
+        alert("Selected file is not InteractiveHtmlBom settings file.");
+        return;
+      }
+      var metadataMatches = newSettings.hasOwnProperty("pcbmetadata");
+      if (metadataMatches) {
+        for (var k in pcbdata.metadata) {
+          if (!newSettings.pcbmetadata.hasOwnProperty(k) || newSettings.pcbmetadata[k] != pcbdata.metadata[k]) {
+            metadataMatches = false;
+          }
+        }
+      }
+      if (!metadataMatches) {
+        var currentMetadata = JSON.stringify(pcbdata.metadata, null, 4);
+        var fileMetadata = JSON.stringify(newSettings.pcbmetadata, null, 4);
+        if (!confirm(
+            `Settins file metadata does not match current metadata.\n\n` +
+            `Page metadata:\n${currentMetadata}\n\n` +
+            `Settings file metadata:\n${fileMetadata}\n\n` +
+            `Press OK if you would like to import settings anyway.`)) {
+          return;
+        }
+      }
+      overwriteSettings(newSettings.settings);
+    }
+    reader.readAsText(file, 'UTF-8');
+  }
+  input.click();
+}
+
+function overwriteSettings(newSettings) {
+  initDone = false;
+  Object.assign(settings, newSettings);
+  writeStorage("bomlayout", settings.bomlayout);
+  writeStorage("bommode", settings.bommode);
+  writeStorage("canvaslayout", settings.canvaslayout);
+  writeStorage("bomCheckboxes", settings.checkboxes.join(","));
+  document.getElementById("bomCheckboxes").value = settings.checkboxes.join(",");
+  for (var checkbox of settings.checkboxes) {
+    writeStorage("checkbox_" + checkbox, settings.checkboxStoredRefs[checkbox]);
+  }
+  writeStorage("markWhenChecked", settings.markWhenChecked);
+  padsVisible(settings.renderPads);
+  document.getElementById("padsCheckbox").checked = settings.renderPads;
+  fabricationVisible(settings.renderFabrication);
+  document.getElementById("fabricationCheckbox").checked = settings.renderFabrication;
+  silkscreenVisible(settings.renderSilkscreen);
+  document.getElementById("silkscreenCheckbox").checked = settings.renderSilkscreen;
+  referencesVisible(settings.renderReferences);
+  document.getElementById("referencesCheckbox").checked = settings.renderReferences;
+  valuesVisible(settings.renderValues);
+  document.getElementById("valuesCheckbox").checked = settings.renderValues;
+  tracksVisible(settings.renderTracks);
+  document.getElementById("tracksCheckbox").checked = settings.renderTracks;
+  zonesVisible(settings.renderZones);
+  document.getElementById("zonesCheckbox").checked = settings.renderZones;
+  dnpOutline(settings.renderDnpOutline);
+  document.getElementById("dnpOutlineCheckbox").checked = settings.renderDnpOutline;
+  setRedrawOnDrag(settings.redrawOnDrag);
+  document.getElementById("dragCheckbox").checked = settings.redrawOnDrag;
+  setDarkMode(settings.darkMode);
+  document.getElementById("darkmodeCheckbox").checked = settings.darkMode;
+  setHighlightPin1(settings.highlightpin1);
+  document.getElementById("highlightpin1Checkbox").checked = settings.highlightpin1;
+  showFootprints(settings.show_footprints);
+  writeStorage("boardRotation", settings.boardRotation);
+  document.getElementById("boardRotation").value = settings.boardRotation / 5;
+  document.getElementById("rotationDegree").textContent = settings.boardRotation;
+  initDone = true;
+  prepCheckboxes();
+  changeBomLayout(settings.bomlayout);
+}
+
+function saveFile(filename, blob) {
+  var link = document.createElement("a");
+  var objurl = URL.createObjectURL(blob);
+  link.download = filename;
+  link.href = objurl;
+  link.click();
+}
+
+function dataURLtoBlob(dataurl) {
+  var arr = dataurl.split(','),
+    mime = arr[0].match(/:(.*?);/)[1],
+    bstr = atob(arr[1]),
+    n = bstr.length,
+    u8arr = new Uint8Array(n);
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+  return new Blob([u8arr], {
+    type: mime
+  });
+}
+
+var settings = {
+  canvaslayout: "default",
+  bomlayout: "default",
+  bommode: "grouped",
+  checkboxes: [],
+  checkboxStoredRefs: {},
+  darkMode: false,
+  highlightpin1: false,
+  redrawOnDrag: true,
+  boardRotation: 0,
+  renderPads: true,
+  renderReferences: true,
+  renderValues: true,
+  renderSilkscreen: true,
+  renderFabrication: true,
+  renderDnpOutline: false,
+  renderTracks: true,
+  renderZones: true,
+  columnOrder: [],
+  hiddenColumns: [],
+}
+
+function initDefaults() {
+  settings.bomlayout = readStorage("bomlayout");
+  if (settings.bomlayout === null) {
+    settings.bomlayout = config.bom_view;
+  }
+  if (!['bom-only', 'left-right', 'top-bottom'].includes(settings.bomlayout)) {
+    settings.bomlayout = config.bom_view;
+  }
+  settings.bommode = readStorage("bommode");
+  if (settings.bommode === null) {
+    settings.bommode = "grouped";
+  }
+  if (!["grouped", "ungrouped", "netlist"].includes(settings.bommode)) {
+    settings.bommode = "grouped";
+  }
+  settings.canvaslayout = readStorage("canvaslayout");
+  if (settings.canvaslayout === null) {
+    settings.canvaslayout = config.layer_view;
+  }
+  var bomCheckboxes = readStorage("bomCheckboxes");
+  if (bomCheckboxes === null) {
+    bomCheckboxes = config.checkboxes;
+  }
+  settings.checkboxes = bomCheckboxes.split(",").filter((e) => e);
+  document.getElementById("bomCheckboxes").value = bomCheckboxes;
+
+  settings.markWhenChecked = readStorage("markWhenChecked") || "";
+  populateMarkWhenCheckedOptions();
+
+  function initBooleanSetting(storageString, def, elementId, func) {
+    var b = readStorage(storageString);
+    if (b === null) {
+      b = def;
+    } else {
+      b = (b == "true");
+    }
+    document.getElementById(elementId).checked = b;
+    func(b);
+  }
+
+  initBooleanSetting("padsVisible", config.show_pads, "padsCheckbox", padsVisible);
+  initBooleanSetting("fabricationVisible", config.show_fabrication, "fabricationCheckbox", fabricationVisible);
+  initBooleanSetting("silkscreenVisible", config.show_silkscreen, "silkscreenCheckbox", silkscreenVisible);
+  initBooleanSetting("referencesVisible", true, "referencesCheckbox", referencesVisible);
+  initBooleanSetting("valuesVisible", true, "valuesCheckbox", valuesVisible);
+  if ("tracks" in pcbdata) {
+    initBooleanSetting("tracksVisible", true, "tracksCheckbox", tracksVisible);
+    initBooleanSetting("zonesVisible", true, "zonesCheckbox", zonesVisible);
+  } else {
+    document.getElementById("tracksAndZonesCheckboxes").style.display = "none";
+    tracksVisible(false);
+    zonesVisible(false);
+  }
+  initBooleanSetting("dnpOutline", false, "dnpOutlineCheckbox", dnpOutline);
+  initBooleanSetting("redrawOnDrag", config.redraw_on_drag, "dragCheckbox", setRedrawOnDrag);
+  initBooleanSetting("darkmode", config.dark_mode, "darkmodeCheckbox", setDarkMode);
+  initBooleanSetting("highlightpin1", config.highlight_pin1, "highlightpin1Checkbox", setHighlightPin1);
+
+  var fields = ["checkboxes", "References"].concat(config.fields).concat(["Quantity"]);
+  var hcols = JSON.parse(readStorage("hiddenColumns"));
+  if (hcols === null) {
+    hcols = [];
+  }
+  settings.hiddenColumns = hcols.filter(e => fields.includes(e));
+
+  var cord = JSON.parse(readStorage("columnOrder"));
+  if (cord === null) {
+    cord = fields;
+  } else {
+    cord = cord.filter(e => fields.includes(e));
+    if (cord.length != fields.length)
+      cord = fields;
+  }
+  settings.columnOrder = cord;
+
+  settings.boardRotation = readStorage("boardRotation");
+  if (settings.boardRotation === null) {
+    settings.boardRotation = config.board_rotation * 5;
+  } else {
+    settings.boardRotation = parseInt(settings.boardRotation);
+  }
+  document.getElementById("boardRotation").value = settings.boardRotation / 5;
+  document.getElementById("rotationDegree").textContent = settings.boardRotation;
+}
+
+// Helper classes for user js callbacks.
+
+const IBOM_EVENT_TYPES = {
+  ALL: "all",
+  HIGHLIGHT_EVENT: "highlightEvent",
+  CHECKBOX_CHANGE_EVENT: "checkboxChangeEvent",
+  BOM_BODY_CHANGE_EVENT: "bomBodyChangeEvent",
+}
+
+const EventHandler = {
+  callbacks: {},
+  init: function() {
+    for (eventType of Object.values(IBOM_EVENT_TYPES))
+      this.callbacks[eventType] = [];
+  },
+  registerCallback: function(eventType, callback) {
+    this.callbacks[eventType].push(callback);
+  },
+  emitEvent: function(eventType, eventArgs) {
+    event = {
+      eventType: eventType,
+      args: eventArgs,
+    }
+    var callback;
+    for (callback of this.callbacks[eventType])
+      callback(event);
+    for (callback of this.callbacks[IBOM_EVENT_TYPES.ALL])
+      callback(event);
+  }
+}
+EventHandler.init();
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+/* PCB rendering code */
+
+var emptyContext2d = document.createElement("canvas").getContext("2d");
+
+function deg2rad(deg) {
+  return deg * Math.PI / 180;
+}
+
+function calcFontPoint(linepoint, text, offsetx, offsety, tilt) {
+  var point = [
+    linepoint[0] * text.width + offsetx,
+    linepoint[1] * text.height + offsety
+  ];
+  // This approximates pcbnew behavior with how text tilts depending on horizontal justification
+  point[0] -= (linepoint[1] + 0.5 * (1 + text.justify[0])) * text.height * tilt;
+  return point;
+}
+
+function drawText(ctx, text, color) {
+  if ("ref" in text && !settings.renderReferences) return;
+  if ("val" in text && !settings.renderValues) return;
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.strokeStyle = color;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.lineWidth = text.thickness;
+  if ("svgpath" in text) {
+    ctx.stroke(new Path2D(text.svgpath));
+    ctx.restore();
+    return;
+  }
+  ctx.translate(...text.pos);
+  ctx.translate(text.thickness * 0.5, 0);
+  var angle = -text.angle;
+  if (text.attr.includes("mirrored")) {
+    ctx.scale(-1, 1);
+    angle = -angle;
+  }
+  var tilt = 0;
+  if (text.attr.includes("italic")) {
+    tilt = 0.125;
+  }
+  var interline = text.height * 1.5 + text.thickness;
+  var txt = text.text.split("\n");
+  // KiCad ignores last empty line.
+  if (txt[txt.length - 1] == '') txt.pop();
+  ctx.rotate(deg2rad(angle));
+  var offsety = (1 - text.justify[1]) / 2 * text.height; // One line offset
+  offsety -= (txt.length - 1) * (text.justify[1] + 1) / 2 * interline; // Multiline offset
+  for (var i in txt) {
+    var lineWidth = text.thickness + interline / 2 * tilt;
+    for (var j = 0; j < txt[i].length; j++) {
+      if (txt[i][j] == '\t') {
+        var fourSpaces = 4 * pcbdata.font_data[' '].w * text.width;
+        lineWidth += fourSpaces - lineWidth % fourSpaces;
+      } else {
+        if (txt[i][j] == '~') {
+          j++;
+          if (j == txt[i].length)
+            break;
+        }
+        lineWidth += pcbdata.font_data[txt[i][j]].w * text.width;
+      }
+    }
+    var offsetx = -lineWidth * (text.justify[0] + 1) / 2;
+    var inOverbar = false;
+    for (var j = 0; j < txt[i].length; j++) {
+      if (txt[i][j] == '\t') {
+        var fourSpaces = 4 * pcbdata.font_data[' '].w * text.width;
+        offsetx += fourSpaces - offsetx % fourSpaces;
+        continue;
+      } else if (txt[i][j] == '~') {
+        j++;
+        if (j == txt[i].length)
+          break;
+        if (txt[i][j] != '~') {
+          inOverbar = !inOverbar;
+        }
+      }
+      var glyph = pcbdata.font_data[txt[i][j]];
+      if (inOverbar) {
+        var overbarStart = [offsetx, -text.height * 1.4 + offsety];
+        var overbarEnd = [offsetx + text.width * glyph.w, overbarStart[1]];
+
+        if (!lastHadOverbar) {
+          overbarStart[0] += text.height * 1.4 * tilt;
+          lastHadOverbar = true;
+        }
+        ctx.beginPath();
+        ctx.moveTo(...overbarStart);
+        ctx.lineTo(...overbarEnd);
+        ctx.stroke();
+      } else {
+        lastHadOverbar = false;
+      }
+      for (var line of glyph.l) {
+        ctx.beginPath();
+        ctx.moveTo(...calcFontPoint(line[0], text, offsetx, offsety, tilt));
+        for (var k = 1; k < line.length; k++) {
+          ctx.lineTo(...calcFontPoint(line[k], text, offsetx, offsety, tilt));
+        }
+        ctx.stroke();
+      }
+      offsetx += glyph.w * text.width;
+    }
+    offsety += interline;
+  }
+  ctx.restore();
+}
+
+function drawedge(ctx, scalefactor, edge, color) {
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = Math.max(1 / scalefactor, edge.width);
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  if ("svgpath" in edge) {
+    ctx.stroke(new Path2D(edge.svgpath));
+  } else {
+    ctx.beginPath();
+    if (edge.type == "segment") {
+      ctx.moveTo(...edge.start);
+      ctx.lineTo(...edge.end);
+    }
+    if (edge.type == "rect") {
+      ctx.moveTo(...edge.start);
+      ctx.lineTo(edge.start[0], edge.end[1]);
+      ctx.lineTo(...edge.end);
+      ctx.lineTo(edge.end[0], edge.start[1]);
+      ctx.lineTo(...edge.start);
+    }
+    if (edge.type == "arc") {
+      ctx.arc(
+        ...edge.start,
+        edge.radius,
+        deg2rad(edge.startangle),
+        deg2rad(edge.endangle));
+    }
+    if (edge.type == "circle") {
+      ctx.arc(
+        ...edge.start,
+        edge.radius,
+        0, 2 * Math.PI);
+      ctx.closePath();
+    }
+    if (edge.type == "curve") {
+      ctx.moveTo(...edge.start);
+      ctx.bezierCurveTo(...edge.cpa, ...edge.cpb, ...edge.end);
+    }
+    if("filled" in edge && edge.filled)
+      ctx.fill();
+    else
+      ctx.stroke();
+  }
+}
+
+function getChamferedRectPath(size, radius, chamfpos, chamfratio) {
+  // chamfpos is a bitmask, left = 1, right = 2, bottom left = 4, bottom right = 8
+  var path = new Path2D();
+  var width = size[0];
+  var height = size[1];
+  var x = width * -0.5;
+  var y = height * -0.5;
+  var chamfOffset = Math.min(width, height) * chamfratio;
+  path.moveTo(x, 0);
+  if (chamfpos & 4) {
+    path.lineTo(x, y + height - chamfOffset);
+    path.lineTo(x + chamfOffset, y + height);
+    path.lineTo(0, y + height);
+  } else {
+    path.arcTo(x, y + height, x + width, y + height, radius);
+  }
+  if (chamfpos & 8) {
+    path.lineTo(x + width - chamfOffset, y + height);
+    path.lineTo(x + width, y + height - chamfOffset);
+    path.lineTo(x + width, 0);
+  } else {
+    path.arcTo(x + width, y + height, x + width, y, radius);
+  }
+  if (chamfpos & 2) {
+    path.lineTo(x + width, y + chamfOffset);
+    path.lineTo(x + width - chamfOffset, y);
+    path.lineTo(0, y);
+  } else {
+    path.arcTo(x + width, y, x, y, radius);
+  }
+  if (chamfpos & 1) {
+    path.lineTo(x + chamfOffset, y);
+    path.lineTo(x, y + chamfOffset);
+    path.lineTo(x, 0);
+  } else {
+    path.arcTo(x, y, x, y + height, radius);
+  }
+  path.closePath();
+  return path;
+}
+
+function getOblongPath(size) {
+  return getChamferedRectPath(size, Math.min(size[0], size[1]) / 2, 0, 0);
+}
+
+function getPolygonsPath(shape) {
+  if (shape.path2d) {
+    return shape.path2d;
+  }
+  if ("svgpath" in shape) {
+    shape.path2d = new Path2D(shape.svgpath);
+  } else {
+    var path = new Path2D();
+    for (var polygon of shape.polygons) {
+      path.moveTo(...polygon[0]);
+      for (var i = 1; i < polygon.length; i++) {
+        path.lineTo(...polygon[i]);
+      }
+      path.closePath();
+    }
+    shape.path2d = path;
+  }
+  return shape.path2d;
+}
+
+function drawPolygonShape(ctx, scalefactor, shape, color) {
+  ctx.save();
+  if (!("svgpath" in shape)) {
+    ctx.translate(...shape.pos);
+    ctx.rotate(deg2rad(-shape.angle));
+  }
+  if("filled" in shape && !shape.filled) {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = Math.max(1 / scalefactor, shape.width);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.stroke(getPolygonsPath(shape));
+  } else {
+    ctx.fillStyle = color;
+    ctx.fill(getPolygonsPath(shape));
+  }
+  ctx.restore();
+}
+
+function drawDrawing(ctx, scalefactor, drawing, color) {
+  if (["segment", "arc", "circle", "curve", "rect"].includes(drawing.type)) {
+    drawedge(ctx, scalefactor, drawing, color);
+  } else if (drawing.type == "polygon") {
+    drawPolygonShape(ctx, scalefactor, drawing, color);
+  } else {
+    drawText(ctx, drawing, color);
+  }
+}
+
+function getCirclePath(radius) {
+  var path = new Path2D();
+  path.arc(0, 0, radius, 0, 2 * Math.PI);
+  path.closePath();
+  return path;
+}
+
+function getCachedPadPath(pad) {
+  if (!pad.path2d) {
+    // if path2d is not set, build one and cache it on pad object
+    if (pad.shape == "rect") {
+      pad.path2d = new Path2D();
+      pad.path2d.rect(...pad.size.map(c => -c * 0.5), ...pad.size);
+    } else if (pad.shape == "oval") {
+      pad.path2d = getOblongPath(pad.size);
+    } else if (pad.shape == "circle") {
+      pad.path2d = getCirclePath(pad.size[0] / 2);
+    } else if (pad.shape == "roundrect") {
+      pad.path2d = getChamferedRectPath(pad.size, pad.radius, 0, 0);
+    } else if (pad.shape == "chamfrect") {
+      pad.path2d = getChamferedRectPath(pad.size, pad.radius, pad.chamfpos, pad.chamfratio)
+    } else if (pad.shape == "custom") {
+      pad.path2d = getPolygonsPath(pad);
+    }
+  }
+  return pad.path2d;
+}
+
+function drawPad(ctx, pad, color, outline) {
+  ctx.save();
+  ctx.translate(...pad.pos);
+  ctx.rotate(deg2rad(pad.angle));
+  if (pad.offset) {
+    ctx.translate(...pad.offset);
+  }
+  ctx.fillStyle = color;
+  ctx.strokeStyle = color;
+  var path = getCachedPadPath(pad);
+  if (outline) {
+    ctx.stroke(path);
+  } else {
+    ctx.fill(path);
+  }
+  ctx.restore();
+}
+
+function drawPadHole(ctx, pad, padHoleColor) {
+  if (pad.type != "th") return;
+  ctx.save();
+  ctx.translate(...pad.pos);
+  ctx.rotate(deg2rad(pad.angle));
+  ctx.fillStyle = padHoleColor;
+  if (pad.drillshape == "oblong") {
+    ctx.fill(getOblongPath(pad.drillsize));
+  } else {
+    ctx.fill(getCirclePath(pad.drillsize[0] / 2));
+  }
+  ctx.restore();
+}
+
+function drawFootprint(ctx, layer, scalefactor, footprint, colors, highlight, outline) {
+  if (highlight) {
+    // draw bounding box
+    if (footprint.layer == layer) {
+      ctx.save();
+      ctx.globalAlpha = 0.2;
+      ctx.translate(...footprint.bbox.pos);
+      ctx.rotate(deg2rad(-footprint.bbox.angle));
+      ctx.translate(...footprint.bbox.relpos);
+      ctx.fillStyle = colors.pad;
+      ctx.fillRect(0, 0, ...footprint.bbox.size);
+      ctx.globalAlpha = 1;
+      ctx.strokeStyle = colors.pad;
+      ctx.strokeRect(0, 0, ...footprint.bbox.size);
+      ctx.restore();
+    }
+  }
+  // draw drawings
+  for (var drawing of footprint.drawings) {
+    if (drawing.layer == layer) {
+      drawDrawing(ctx, scalefactor, drawing.drawing, colors.pad);
+    }
+  }
+  // draw pads
+  if (settings.renderPads) {
+    for (var pad of footprint.pads) {
+      if (pad.layers.includes(layer)) {
+        drawPad(ctx, pad, colors.pad, outline);
+        if (pad.pin1 && settings.highlightpin1) {
+          drawPad(ctx, pad, colors.outline, true);
+        }
+      }
+    }
+    for (var pad of footprint.pads) {
+      drawPadHole(ctx, pad, colors.padHole);
+    }
+  }
+}
+
+function drawEdgeCuts(canvas, scalefactor) {
+  var ctx = canvas.getContext("2d");
+  var edgecolor = getComputedStyle(topmostdiv).getPropertyValue('--pcb-edge-color');
+  for (var edge of pcbdata.edges) {
+    drawDrawing(ctx, scalefactor, edge, edgecolor);
+  }
+}
+
+function drawFootprints(canvas, layer, scalefactor, highlight) {
+  var ctx = canvas.getContext("2d");
+  ctx.lineWidth = 3 / scalefactor;
+  var style = getComputedStyle(topmostdiv);
+
+  var colors = {
+    pad: style.getPropertyValue('--pad-color'),
+    padHole: style.getPropertyValue('--pad-hole-color'),
+    outline: style.getPropertyValue('--pin1-outline-color'),
+  }
+
+  for (var i = 0; i < pcbdata.footprints.length; i++) {
+    var mod = pcbdata.footprints[i];
+    var outline = settings.renderDnpOutline && pcbdata.bom.skipped.includes(i);
+    var h = highlightedFootprints.includes(i);
+    var d = markedFootprints.has(i);
+    if (highlight) {
+      if(h && d) {
+        colors.pad = style.getPropertyValue('--pad-color-highlight-both');
+        colors.outline = style.getPropertyValue('--pin1-outline-color-highlight-both');
+      } else if (h) {
+        colors.pad = style.getPropertyValue('--pad-color-highlight');
+        colors.outline = style.getPropertyValue('--pin1-outline-color-highlight');
+      } else if (d) {
+        colors.pad = style.getPropertyValue('--pad-color-highlight-marked');
+        colors.outline = style.getPropertyValue('--pin1-outline-color-highlight-marked');
+      }
+    }
+    if( h || d || !highlight) {
+      drawFootprint(ctx, layer, scalefactor, mod, colors, highlight, outline);
+    }
+  }
+}
+
+function drawBgLayer(layername, canvas, layer, scalefactor, edgeColor, polygonColor, textColor) {
+  var ctx = canvas.getContext("2d");
+  for (var d of pcbdata.drawings[layername][layer]) {
+    if (["segment", "arc", "circle", "curve", "rect"].includes(d.type)) {
+      drawedge(ctx, scalefactor, d, edgeColor);
+    } else if (d.type == "polygon") {
+      drawPolygonShape(ctx, scalefactor, d, polygonColor);
+    } else {
+      drawText(ctx, d, textColor);
+    }
+  }
+}
+
+function drawTracks(canvas, layer, color, highlight) {
+  ctx = canvas.getContext("2d");
+  ctx.strokeStyle = color;
+  ctx.lineCap = "round";
+  for (var track of pcbdata.tracks[layer]) {
+    if (highlight && highlightedNet != track.net) continue;
+    ctx.lineWidth = track.width;
+    ctx.beginPath();
+    if ('radius' in track) {
+      ctx.arc(
+        ...track.center,
+        track.radius,
+        deg2rad(track.startangle),
+        deg2rad(track.endangle));
+    } else {
+      ctx.moveTo(...track.start);
+      ctx.lineTo(...track.end);
+    }
+    ctx.stroke();
+  }
+}
+
+function drawZones(canvas, layer, color, highlight) {
+  ctx = canvas.getContext("2d");
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineJoin = "round";
+  for (var zone of pcbdata.zones[layer]) {
+    if (!zone.path2d) {
+      zone.path2d = getPolygonsPath(zone);
+    }
+    if (highlight && highlightedNet != zone.net) continue;
+    ctx.fill(zone.path2d);
+    if (zone.width > 0) {
+      ctx.lineWidth = zone.width;
+      ctx.stroke(zone.path2d);
+    }
+  }
+}
+
+function clearCanvas(canvas, color = null) {
+  var ctx = canvas.getContext("2d");
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  if (color) {
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  } else {
+    if (!window.matchMedia("print").matches)
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+  ctx.restore();
+}
+
+function drawNets(canvas, layer, highlight) {
+  var style = getComputedStyle(topmostdiv);
+  if (settings.renderTracks) {
+    var trackColor = style.getPropertyValue(highlight ? '--track-color-highlight' : '--track-color');
+    drawTracks(canvas, layer, trackColor, highlight);
+  }
+  if (settings.renderZones) {
+    var zoneColor = style.getPropertyValue(highlight ? '--zone-color-highlight' : '--zone-color');
+    drawZones(canvas, layer, zoneColor, highlight);
+  }
+  if (highlight && settings.renderPads) {
+    var padColor = style.getPropertyValue('--pad-color-highlight');
+    var padHoleColor = style.getPropertyValue('--pad-hole-color');
+    var ctx = canvas.getContext("2d");
+    for (var footprint of pcbdata.footprints) {
+      // draw pads
+      var padDrawn = false;
+      for (var pad of footprint.pads) {
+        if (highlightedNet != pad.net) continue;
+        if (pad.layers.includes(layer)) {
+          drawPad(ctx, pad, padColor, false);
+          padDrawn = true;
+        }
+      }
+      if (padDrawn) {
+        // redraw all pad holes because some pads may overlap
+        for (var pad of footprint.pads) {
+          drawPadHole(ctx, pad, padHoleColor);
+        }
+      }
+    }
+  }
+}
+
+function drawHighlightsOnLayer(canvasdict, clear = true) {
+  if (clear) {
+    clearCanvas(canvasdict.highlight);
+  }
+  if (markedFootprints.size > 0 || highlightedFootprints.length > 0) {
+    drawFootprints(canvasdict.highlight, canvasdict.layer,
+      canvasdict.transform.s * canvasdict.transform.zoom, true);
+  }
+  if (highlightedNet !== null) {
+    drawNets(canvasdict.highlight, canvasdict.layer, true);
+  }
+}
+
+function drawHighlights() {
+  drawHighlightsOnLayer(allcanvas.front);
+  drawHighlightsOnLayer(allcanvas.back);
+}
+
+function drawBackground(canvasdict, clear = true) {
+  if (clear) {
+    clearCanvas(canvasdict.bg);
+    clearCanvas(canvasdict.fab);
+    clearCanvas(canvasdict.silk);
+  }
+
+  drawNets(canvasdict.bg, canvasdict.layer, false);
+  drawFootprints(canvasdict.bg, canvasdict.layer,
+    canvasdict.transform.s * canvasdict.transform.zoom, false);
+
+  drawEdgeCuts(canvasdict.bg, canvasdict.transform.s * canvasdict.transform.zoom);
+
+  var style = getComputedStyle(topmostdiv);
+  var edgeColor = style.getPropertyValue('--silkscreen-edge-color');
+  var polygonColor = style.getPropertyValue('--silkscreen-polygon-color');
+  var textColor = style.getPropertyValue('--silkscreen-text-color');
+  if (settings.renderSilkscreen) {
+    drawBgLayer(
+      "silkscreen", canvasdict.silk, canvasdict.layer,
+      canvasdict.transform.s * canvasdict.transform.zoom,
+      edgeColor, polygonColor, textColor);
+  }
+  edgeColor = style.getPropertyValue('--fabrication-edge-color');
+  polygonColor = style.getPropertyValue('--fabrication-polygon-color');
+  textColor = style.getPropertyValue('--fabrication-text-color');
+  if (settings.renderFabrication) {
+    drawBgLayer(
+      "fabrication", canvasdict.fab, canvasdict.layer,
+      canvasdict.transform.s * canvasdict.transform.zoom,
+      edgeColor, polygonColor, textColor);
+  }
+}
+
+function prepareCanvas(canvas, flip, transform) {
+  var ctx = canvas.getContext("2d");
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  var fontsize = 1.55;
+  ctx.scale(transform.zoom, transform.zoom);
+  ctx.translate(transform.panx, transform.pany);
+  if (flip) {
+    ctx.scale(-1, 1);
+  }
+  ctx.translate(transform.x, transform.y);
+  ctx.rotate(deg2rad(settings.boardRotation));
+  ctx.scale(transform.s, transform.s);
+}
+
+function prepareLayer(canvasdict) {
+  var flip = (canvasdict.layer == "B");
+  for (var c of ["bg", "fab", "silk", "highlight"]) {
+    prepareCanvas(canvasdict[c], flip, canvasdict.transform);
+  }
+}
+
+function rotateVector(v, angle) {
+  angle = deg2rad(angle);
+  return [
+    v[0] * Math.cos(angle) - v[1] * Math.sin(angle),
+    v[0] * Math.sin(angle) + v[1] * Math.cos(angle)
+  ];
+}
+
+function applyRotation(bbox) {
+  var corners = [
+    [bbox.minx, bbox.miny],
+    [bbox.minx, bbox.maxy],
+    [bbox.maxx, bbox.miny],
+    [bbox.maxx, bbox.maxy],
+  ];
+  corners = corners.map((v) => rotateVector(v, settings.boardRotation));
+  return {
+    minx: corners.reduce((a, v) => Math.min(a, v[0]), Infinity),
+    miny: corners.reduce((a, v) => Math.min(a, v[1]), Infinity),
+    maxx: corners.reduce((a, v) => Math.max(a, v[0]), -Infinity),
+    maxy: corners.reduce((a, v) => Math.max(a, v[1]), -Infinity),
+  }
+}
+
+function recalcLayerScale(layerdict, width, height) {
+  var bbox = applyRotation(pcbdata.edges_bbox);
+  var scalefactor = 0.98 * Math.min(
+    width / (bbox.maxx - bbox.minx),
+    height / (bbox.maxy - bbox.miny)
+  );
+  if (scalefactor < 0.1) {
+    scalefactor = 1;
+  }
+  layerdict.transform.s = scalefactor;
+  var flip = (layerdict.layer == "B");
+  if (flip) {
+    layerdict.transform.x = -((bbox.maxx + bbox.minx) * scalefactor + width) * 0.5;
+  } else {
+    layerdict.transform.x = -((bbox.maxx + bbox.minx) * scalefactor - width) * 0.5;
+  }
+  layerdict.transform.y = -((bbox.maxy + bbox.miny) * scalefactor - height) * 0.5;
+  for (var c of ["bg", "fab", "silk", "highlight"]) {
+    canvas = layerdict[c];
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.width = (width / devicePixelRatio) + "px";
+    canvas.style.height = (height / devicePixelRatio) + "px";
+  }
+}
+
+function redrawCanvas(layerdict) {
+  prepareLayer(layerdict);
+  drawBackground(layerdict);
+  drawHighlightsOnLayer(layerdict);
+}
+
+function resizeCanvas(layerdict) {
+  var canvasdivid = {
+    "F": "frontcanvas",
+    "B": "backcanvas"
+  } [layerdict.layer];
+  var width = document.getElementById(canvasdivid).clientWidth * devicePixelRatio;
+  var height = document.getElementById(canvasdivid).clientHeight * devicePixelRatio;
+  recalcLayerScale(layerdict, width, height);
+  redrawCanvas(layerdict);
+}
+
+function resizeAll() {
+  resizeCanvas(allcanvas.front);
+  resizeCanvas(allcanvas.back);
+}
+
+function pointWithinDistanceToSegment(x, y, x1, y1, x2, y2, d) {
+  var A = x - x1;
+  var B = y - y1;
+  var C = x2 - x1;
+  var D = y2 - y1;
+
+  var dot = A * C + B * D;
+  var len_sq = C * C + D * D;
+  var dx, dy;
+  if (len_sq == 0) {
+    // start and end of the segment coincide
+    dx = x - x1;
+    dy = y - y1;
+  } else {
+    var param = dot / len_sq;
+    var xx, yy;
+    if (param < 0) {
+      xx = x1;
+      yy = y1;
+    } else if (param > 1) {
+      xx = x2;
+      yy = y2;
+    } else {
+      xx = x1 + param * C;
+      yy = y1 + param * D;
+    }
+    dx = x - xx;
+    dy = y - yy;
+  }
+  return dx * dx + dy * dy <= d * d;
+}
+
+function modulo(n, mod) {
+  return ((n % mod) + mod) % mod;
+}
+
+function pointWithinDistanceToArc(x, y, xc, yc, radius, startangle, endangle, d) {
+  var dx = x - xc;
+  var dy = y - yc;
+  var r_sq = dx * dx + dy * dy;
+  var rmin = Math.max(0, radius - d);
+  var rmax = radius + d;
+
+  if (r_sq < rmin * rmin || r_sq > rmax * rmax)
+    return false;
+
+  var angle1 = modulo(deg2rad(startangle), 2 * Math.PI);
+  var dx1 = xc + radius * Math.cos(angle1) - x;
+  var dy1 = yc + radius * Math.sin(angle1) - y;
+  if (dx1 * dx1 + dy1 * dy1 <= d * d)
+    return true;
+
+  var angle2 = modulo(deg2rad(endangle), 2 * Math.PI);
+  var dx2 = xc + radius * Math.cos(angle2) - x;
+  var dy2 = yc + radius * Math.sin(angle2) - y;
+  if (dx2 * dx2 + dy2 * dy2 <= d * d)
+    return true;
+
+  var angle = modulo(Math.atan2(dy, dx), 2 * Math.PI);
+  if (angle1 > angle2)
+    return (angle >= angle2 || angle <= angle1);
+  else
+    return (angle >= angle1 && angle <= angle2);
+}
+
+function pointWithinPad(x, y, pad) {
+  var v = [x - pad.pos[0], y - pad.pos[1]];
+  v = rotateVector(v, -pad.angle);
+  if (pad.offset) {
+    v[0] -= pad.offset[0];
+    v[1] -= pad.offset[1];
+  }
+  return emptyContext2d.isPointInPath(getCachedPadPath(pad), ...v);
+}
+
+function netHitScan(layer, x, y) {
+  // Check track segments
+  if (settings.renderTracks && pcbdata.tracks) {
+    for (var track of pcbdata.tracks[layer]) {
+      if ('radius' in track) {
+        if (pointWithinDistanceToArc(x, y, ...track.center, track.radius, track.startangle, track.endangle, track.width / 2)) {
+          return track.net;
+        }
+      } else {
+        if (pointWithinDistanceToSegment(x, y, ...track.start, ...track.end, track.width / 2)) {
+          return track.net;
+        }
+      }
+    }
+  }
+  // Check pads
+  if (settings.renderPads) {
+    for (var footprint of pcbdata.footprints) {
+      for (var pad of footprint.pads) {
+        if (pad.layers.includes(layer) && pointWithinPad(x, y, pad)) {
+          return pad.net;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function pointWithinFootprintBbox(x, y, bbox) {
+  var v = [x - bbox.pos[0], y - bbox.pos[1]];
+  v = rotateVector(v, bbox.angle);
+  return bbox.relpos[0] <= v[0] && v[0] <= bbox.relpos[0] + bbox.size[0] &&
+    bbox.relpos[1] <= v[1] && v[1] <= bbox.relpos[1] + bbox.size[1];
+}
+
+function bboxHitScan(layer, x, y) {
+  var result = [];
+  for (var i = 0; i < pcbdata.footprints.length; i++) {
+    var footprint = pcbdata.footprints[i];
+    if (footprint.layer == layer) {
+      if (pointWithinFootprintBbox(x, y, footprint.bbox)) {
+        result.push(i);
+      }
+    }
+  }
+  return result;
+}
+
+function handlePointerDown(e, layerdict) {
+  if (e.button != 0 && e.button != 1) {
+    return;
+  }
+  e.preventDefault();
+  e.stopPropagation();
+
+  if (!e.hasOwnProperty("offsetX")) {
+    // The polyfill doesn't set this properly
+    e.offsetX = e.pageX - e.currentTarget.offsetLeft;
+    e.offsetY = e.pageY - e.currentTarget.offsetTop;
+  }
+
+  layerdict.pointerStates[e.pointerId] = {
+    distanceTravelled: 0,
+    lastX: e.offsetX,
+    lastY: e.offsetY,
+    downTime: Date.now(),
+  };
+}
+
+function handleMouseClick(e, layerdict) {
+  if (!e.hasOwnProperty("offsetX")) {
+    // The polyfill doesn't set this properly
+    e.offsetX = e.pageX - e.currentTarget.offsetLeft;
+    e.offsetY = e.pageY - e.currentTarget.offsetTop;
+  }
+
+  var x = e.offsetX;
+  var y = e.offsetY;
+  var t = layerdict.transform;
+  if (layerdict.layer == "B") {
+    x = (devicePixelRatio * x / t.zoom - t.panx + t.x) / -t.s;
+  } else {
+    x = (devicePixelRatio * x / t.zoom - t.panx - t.x) / t.s;
+  }
+  y = (devicePixelRatio * y / t.zoom - t.y - t.pany) / t.s;
+  var v = rotateVector([x, y], -settings.boardRotation);
+  if ("nets" in pcbdata) {
+    var net = netHitScan(layerdict.layer, ...v);
+    if (net !== highlightedNet) {
+      netClicked(net);
+    }
+  }
+  if (highlightedNet === null) {
+    var footprints = bboxHitScan(layerdict.layer, ...v);
+    if (footprints.length > 0) {
+      footprintsClicked(footprints);
+    }
+  }
+}
+
+function handlePointerLeave(e, layerdict) {
+  e.preventDefault();
+  e.stopPropagation();
+
+  if (!settings.redrawOnDrag) {
+    redrawCanvas(layerdict);
+  }
+
+  delete layerdict.pointerStates[e.pointerId];
+}
+
+function resetTransform(layerdict) {
+  layerdict.transform.panx = 0;
+  layerdict.transform.pany = 0;
+  layerdict.transform.zoom = 1;
+  redrawCanvas(layerdict);
+}
+
+function handlePointerUp(e, layerdict) {
+  if (!e.hasOwnProperty("offsetX")) {
+    // The polyfill doesn't set this properly
+    e.offsetX = e.pageX - e.currentTarget.offsetLeft;
+    e.offsetY = e.pageY - e.currentTarget.offsetTop;
+  }
+
+  e.preventDefault();
+  e.stopPropagation();
+
+  if (e.button == 2) {
+    // Reset pan and zoom on right click.
+    resetTransform(layerdict);
+    layerdict.anotherPointerTapped = false;
+    return;
+  }
+
+  // We haven't necessarily had a pointermove event since the interaction started, so make sure we update this now
+  var ptr = layerdict.pointerStates[e.pointerId];
+  ptr.distanceTravelled += Math.abs(e.offsetX - ptr.lastX) + Math.abs(e.offsetY - ptr.lastY);
+
+  if (e.button == 0 && ptr.distanceTravelled < 10 && Date.now() - ptr.downTime <= 500) {
+    if (Object.keys(layerdict.pointerStates).length == 1) {
+      if (layerdict.anotherPointerTapped) {
+        // This is the second pointer coming off of a two-finger tap
+        resetTransform(layerdict);
+      } else {
+        // This is just a regular tap
+        handleMouseClick(e, layerdict);
+      }
+      layerdict.anotherPointerTapped = false;
+    } else {
+      // This is the first finger coming off of what could become a two-finger tap
+      layerdict.anotherPointerTapped = true;
+    }
+  } else {
+    if (!settings.redrawOnDrag) {
+      redrawCanvas(layerdict);
+    }
+    layerdict.anotherPointerTapped = false;
+  }
+
+  delete layerdict.pointerStates[e.pointerId];
+}
+
+function handlePointerMove(e, layerdict) {
+  if (!layerdict.pointerStates.hasOwnProperty(e.pointerId)) {
+    return;
+  }
+  e.preventDefault();
+  e.stopPropagation();
+
+  if (!e.hasOwnProperty("offsetX")) {
+    // The polyfill doesn't set this properly
+    e.offsetX = e.pageX - e.currentTarget.offsetLeft;
+    e.offsetY = e.pageY - e.currentTarget.offsetTop;
+  }
+
+  var thisPtr = layerdict.pointerStates[e.pointerId];
+
+  var dx = e.offsetX - thisPtr.lastX;
+  var dy = e.offsetY - thisPtr.lastY;
+
+  // If this number is low on pointer up, we count the action as a click
+  thisPtr.distanceTravelled += Math.abs(dx) + Math.abs(dy);
+
+  if (Object.keys(layerdict.pointerStates).length == 1) {
+    // This is a simple drag
+    layerdict.transform.panx += devicePixelRatio * dx / layerdict.transform.zoom;
+    layerdict.transform.pany += devicePixelRatio * dy / layerdict.transform.zoom;
+  } else if (Object.keys(layerdict.pointerStates).length == 2) {
+    var otherPtr = Object.values(layerdict.pointerStates).filter((ptr) => ptr != thisPtr)[0];
+
+    var oldDist = Math.sqrt(Math.pow(thisPtr.lastX - otherPtr.lastX, 2) + Math.pow(thisPtr.lastY - otherPtr.lastY, 2));
+    var newDist = Math.sqrt(Math.pow(e.offsetX - otherPtr.lastX, 2) + Math.pow(e.offsetY - otherPtr.lastY, 2));
+
+    var scaleFactor = newDist / oldDist;
+
+    if (scaleFactor != NaN) {
+      layerdict.transform.zoom *= scaleFactor;
+
+      var zoomd = (1 - scaleFactor) / layerdict.transform.zoom;
+      layerdict.transform.panx += devicePixelRatio * otherPtr.lastX * zoomd;
+      layerdict.transform.pany += devicePixelRatio * otherPtr.lastY * zoomd;
+    }
+  }
+
+  thisPtr.lastX = e.offsetX;
+  thisPtr.lastY = e.offsetY;
+
+  if (settings.redrawOnDrag) {
+    redrawCanvas(layerdict);
+  }
+}
+
+function handleMouseWheel(e, layerdict) {
+  e.preventDefault();
+  e.stopPropagation();
+  var t = layerdict.transform;
+  var wheeldelta = e.deltaY;
+  if (e.deltaMode == 1) {
+    // FF only, scroll by lines
+    wheeldelta *= 30;
+  } else if (e.deltaMode == 2) {
+    wheeldelta *= 300;
+  }
+  var m = Math.pow(1.1, -wheeldelta / 40);
+  // Limit amount of zoom per tick.
+  if (m > 2) {
+    m = 2;
+  } else if (m < 0.5) {
+    m = 0.5;
+  }
+  t.zoom *= m;
+  var zoomd = (1 - m) / t.zoom;
+  t.panx += devicePixelRatio * e.offsetX * zoomd;
+  t.pany += devicePixelRatio * e.offsetY * zoomd;
+  redrawCanvas(layerdict);
+}
+
+function addMouseHandlers(div, layerdict) {
+  div.addEventListener("pointerdown", function(e) {
+    handlePointerDown(e, layerdict);
+  });
+  div.addEventListener("pointermove", function(e) {
+    handlePointerMove(e, layerdict);
+  });
+  div.addEventListener("pointerup", function(e) {
+    handlePointerUp(e, layerdict);
+  });
+  var pointerleave = function(e) {
+    handlePointerLeave(e, layerdict);
+  }
+  div.addEventListener("pointercancel", pointerleave);
+  div.addEventListener("pointerleave", pointerleave);
+  div.addEventListener("pointerout", pointerleave);
+
+  div.onwheel = function(e) {
+    handleMouseWheel(e, layerdict);
+  }
+  for (var element of [div, layerdict.bg, layerdict.fab, layerdict.silk, layerdict.highlight]) {
+    element.addEventListener("contextmenu", function(e) {
+      e.preventDefault();
+    }, false);
+  }
+}
+
+function setRedrawOnDrag(value) {
+  settings.redrawOnDrag = value;
+  writeStorage("redrawOnDrag", value);
+}
+
+function setBoardRotation(value) {
+  settings.boardRotation = value * 5;
+  writeStorage("boardRotation", settings.boardRotation);
+  document.getElementById("rotationDegree").textContent = settings.boardRotation;
+  resizeAll();
+}
+
+function initRender() {
+  allcanvas = {
+    front: {
+      transform: {
+        x: 0,
+        y: 0,
+        s: 1,
+        panx: 0,
+        pany: 0,
+        zoom: 1,
+      },
+      pointerStates: {},
+      anotherPointerTapped: false,
+      bg: document.getElementById("F_bg"),
+      fab: document.getElementById("F_fab"),
+      silk: document.getElementById("F_slk"),
+      highlight: document.getElementById("F_hl"),
+      layer: "F",
+    },
+    back: {
+      transform: {
+        x: 0,
+        y: 0,
+        s: 1,
+        panx: 0,
+        pany: 0,
+        zoom: 1,
+      },
+      pointerStates: {},
+      anotherPointerTapped: false,
+      bg: document.getElementById("B_bg"),
+      fab: document.getElementById("B_fab"),
+      silk: document.getElementById("B_slk"),
+      highlight: document.getElementById("B_hl"),
+      layer: "B",
+    }
+  };
+  addMouseHandlers(document.getElementById("frontcanvas"), allcanvas.front);
+  addMouseHandlers(document.getElementById("backcanvas"), allcanvas.back);
+}
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+/*
+ * Table reordering via Drag'n'Drop
+ * Inspired by: https://htmldom.dev/drag-and-drop-table-column
+ */
+
+function setBomHandlers() {
+
+  const bom = document.getElementById('bomtable');
+
+  let dragName;
+  let placeHolderElements;
+  let draggingElement;
+  let forcePopulation;
+  let xOffset;
+  let yOffset;
+  let wasDragged;
+
+  const mouseUpHandler = function(e) {
+    // Delete dragging element
+    draggingElement.remove();
+
+    // Make BOM selectable again
+    bom.style.removeProperty("userSelect");
+
+    // Remove listeners
+    document.removeEventListener('mousemove', mouseMoveHandler);
+    document.removeEventListener('mouseup', mouseUpHandler);
+
+    if (wasDragged) {
+      // Redraw whole BOM
+      populateBomTable();
+    }
+  }
+
+  const mouseMoveHandler = function(e) {
+    // Notice the dragging
+    wasDragged = true;
+
+    // Make the dragged element visible
+    draggingElement.style.removeProperty("display");
+
+    // Set elements position to mouse position
+    draggingElement.style.left = `${e.screenX - xOffset}px`;
+    draggingElement.style.top = `${e.screenY - yOffset}px`;
+
+    // Forced redrawing of BOM table
+    if (forcePopulation) {
+      forcePopulation = false;
+      // Copy array
+      phe = Array.from(placeHolderElements);
+      // populate BOM table again
+      populateBomHeader(dragName, phe);
+      populateBomBody(dragName, phe);
+    }
+
+    // Set up array of hidden columns
+    var hiddenColumns = Array.from(settings.hiddenColumns);
+    // In the ungrouped mode, quantity don't exist
+    if (settings.bommode === "ungrouped")
+      hiddenColumns.push("Quantity");
+    // If no checkbox fields can be found, we consider them hidden
+    if (settings.checkboxes.length == 0)
+      hiddenColumns.push("checkboxes");
+
+    // Get table headers and group them into checkboxes, extrafields and normal headers
+    const bh = document.getElementById("bomhead");
+    headers = Array.from(bh.querySelectorAll("th"))
+    headers.shift() // numCol is not part of the columnOrder
+    headerGroups = []
+    lastCompoundClass = null;
+    for (i = 0; i < settings.columnOrder.length; i++) {
+      cElem = settings.columnOrder[i];
+      if (hiddenColumns.includes(cElem)) {
+        // Hidden columns appear as a dummy element
+        headerGroups.push([]);
+        continue;
+      }
+      elem = headers.filter(e => getColumnOrderName(e) === cElem)[0];
+      if (elem.classList.contains("bom-checkbox")) {
+        if (lastCompoundClass === "bom-checkbox") {
+          cbGroup = headerGroups.pop();
+          cbGroup.push(elem);
+          headerGroups.push(cbGroup);
+        } else {
+          lastCompoundClass = "bom-checkbox";
+          headerGroups.push([elem])
+        }
+      } else {
+        headerGroups.push([elem])
+      }
+    }
+
+    // Copy settings.columnOrder
+    var columns = Array.from(settings.columnOrder)
+
+    // Set up array with indices of hidden columns
+    var hiddenIndices = hiddenColumns.map(e => settings.columnOrder.indexOf(e));
+    var dragIndex = columns.indexOf(dragName);
+    var swapIndex = dragIndex;
+    var swapDone = false;
+
+    // Check if the current dragged element is swapable with the left or right element
+    if (dragIndex > 0) {
+      // Get left headers boundingbox
+      swapIndex = dragIndex - 1;
+      while (hiddenIndices.includes(swapIndex) && swapIndex > 0)
+        swapIndex--;
+      if (!hiddenIndices.includes(swapIndex)) {
+        box = getBoundingClientRectFromMultiple(headerGroups[swapIndex]);
+        if (e.clientX < box.left + window.scrollX + (box.width / 2)) {
+          swapElement = columns[dragIndex];
+          columns.splice(dragIndex, 1);
+          columns.splice(swapIndex, 0, swapElement);
+          forcePopulation = true;
+          swapDone = true;
+        }
+      }
+    }
+    if ((!swapDone) && dragIndex < headerGroups.length - 1) {
+      // Get right headers boundingbox
+      swapIndex = dragIndex + 1;
+      while (hiddenIndices.includes(swapIndex))
+        swapIndex++;
+      if (swapIndex < headerGroups.length) {
+        box = getBoundingClientRectFromMultiple(headerGroups[swapIndex]);
+        if (e.clientX > box.left + window.scrollX + (box.width / 2)) {
+          swapElement = columns[dragIndex];
+          columns.splice(dragIndex, 1);
+          columns.splice(swapIndex, 0, swapElement);
+          forcePopulation = true;
+          swapDone = true;
+        }
+      }
+    }
+
+    // Write back change to storage
+    if (swapDone) {
+      settings.columnOrder = columns
+      writeStorage("columnOrder", JSON.stringify(columns));
+    }
+
+  }
+
+  const mouseDownHandler = function(e) {
+    var target = e.target;
+    if (target.tagName.toLowerCase() != "td")
+      target = target.parentElement;
+
+    // Used to check if a dragging has ever happened
+    wasDragged = false;
+
+    // Create new element which will be displayed as the dragged column
+    draggingElement = document.createElement("div")
+    draggingElement.classList.add("dragging");
+    draggingElement.style.display = "none";
+    draggingElement.style.position = "absolute";
+    draggingElement.style.overflow = "hidden";
+
+    // Get bomhead and bombody elements
+    const bh = document.getElementById("bomhead");
+    const bb = document.getElementById("bombody");
+
+    // Get all compound headers for the current column
+    var compoundHeaders;
+    if (target.classList.contains("bom-checkbox")) {
+      compoundHeaders = Array.from(bh.querySelectorAll("th.bom-checkbox"));
+    } else {
+      compoundHeaders = [target];
+    }
+
+    // Create new table which will display the column
+    var newTable = document.createElement("table");
+    newTable.classList.add("bom");
+    newTable.style.background = "white";
+    draggingElement.append(newTable);
+
+    // Create new header element
+    var newHeader = document.createElement("thead");
+    newTable.append(newHeader);
+
+    // Set up array for storing all placeholder elements
+    placeHolderElements = [];
+
+    // Add all compound headers to the new thead element and placeholders
+    compoundHeaders.forEach(function(h) {
+      clone = cloneElementWithDimensions(h);
+      newHeader.append(clone);
+      placeHolderElements.push(clone);
+    });
+
+    // Create new body element
+    var newBody = document.createElement("tbody");
+    newTable.append(newBody);
+
+    // Get indices for compound headers
+    var idxs = compoundHeaders.map(e => getBomTableHeaderIndex(e));
+
+    // For each row in the BOM body...
+    var rows = bb.querySelectorAll("tr");
+    rows.forEach(function(row) {
+      // ..get the cells for the compound column
+      const tds = row.querySelectorAll("td");
+      var copytds = idxs.map(i => tds[i]);
+      // Add them to the new element and the placeholders
+      var newRow = document.createElement("tr");
+      copytds.forEach(function(td) {
+        clone = cloneElementWithDimensions(td);
+        newRow.append(clone);
+        placeHolderElements.push(clone);
+      });
+      newBody.append(newRow);
+    });
+
+    // Compute width for compound header
+    var width = compoundHeaders.reduce((acc, x) => acc + x.clientWidth, 0);
+    draggingElement.style.width = `${width}px`;
+
+    // Insert the new dragging element and disable selection on BOM
+    bom.insertBefore(draggingElement, null);
+    bom.style.userSelect = "none";
+
+    // Determine the mouse position offset
+    xOffset = e.screenX - compoundHeaders.reduce((acc, x) => Math.min(acc, x.offsetLeft), compoundHeaders[0].offsetLeft);
+    yOffset = e.screenY - compoundHeaders[0].offsetTop;
+
+    // Get name for the column in settings.columnOrder
+    dragName = getColumnOrderName(target);
+
+    // Change text and class for placeholder elements
+    placeHolderElements = placeHolderElements.map(function(e) {
+      newElem = cloneElementWithDimensions(e);
+      newElem.textContent = "";
+      newElem.classList.add("placeholder");
+      return newElem;
+    });
+
+    // On next mouse move, the whole BOM needs to be redrawn to show the placeholders
+    forcePopulation = true;
+
+    // Add listeners for move and up on mouse
+    document.addEventListener('mousemove', mouseMoveHandler);
+    document.addEventListener('mouseup', mouseUpHandler);
+  }
+
+  // In netlist mode, there is nothing to reorder
+  if (settings.bommode === "netlist")
+    return;
+
+  // Add mouseDownHandler to every column except the numCol
+  bom.querySelectorAll("th")
+    .forEach(function(head) {
+      if (!head.classList.contains("numCol")) {
+        head.onmousedown = mouseDownHandler;
+      }
+    });
+
+}
+
+function getBoundingClientRectFromMultiple(elements) {
+  var elems = Array.from(elements);
+
+  if (elems.length == 0)
+    return null;
+
+  var box = elems.shift()
+    .getBoundingClientRect();
+
+  elems.forEach(function(elem) {
+    var elembox = elem.getBoundingClientRect();
+    box.left = Math.min(elembox.left, box.left);
+    box.top = Math.min(elembox.top, box.top);
+    box.width += elembox.width;
+    box.height = Math.max(elembox.height, box.height);
+  });
+
+  return box;
+}
+
+function cloneElementWithDimensions(elem) {
+  var newElem = elem.cloneNode(true);
+  newElem.style.height = window.getComputedStyle(elem).height;
+  newElem.style.width = window.getComputedStyle(elem).width;
+  return newElem;
+}
+
+function getBomTableHeaderIndex(elem) {
+  const bh = document.getElementById('bomhead');
+  const ths = Array.from(bh.querySelectorAll("th"));
+  return ths.indexOf(elem);
+}
+
+function getColumnOrderName(elem) {
+  var cname = elem.getAttribute("col_name");
+  if (cname === "bom-checkbox")
+    return "checkboxes";
+  else
+    return cname;
+}
+
+function resizableGrid(tablehead) {
+  var cols = tablehead.firstElementChild.children;
+  var rowWidth = tablehead.offsetWidth;
+
+  for (var i = 1; i < cols.length; i++) {
+    if (cols[i].classList.contains("bom-checkbox"))
+      continue;
+    cols[i].style.width = ((cols[i].clientWidth - paddingDiff(cols[i])) * 100 / rowWidth) + '%';
+  }
+
+  for (var i = 1; i < cols.length - 1; i++) {
+    var div = document.createElement('div');
+    div.className = "column-width-handle";
+    cols[i].appendChild(div);
+    setListeners(div);
+  }
+
+  function setListeners(div) {
+    var startX, curCol, nxtCol, curColWidth, nxtColWidth, rowWidth;
+
+    div.addEventListener('mousedown', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      curCol = e.target.parentElement;
+      nxtCol = curCol.nextElementSibling;
+      startX = e.pageX;
+
+      var padding = paddingDiff(curCol);
+
+      rowWidth = curCol.parentElement.offsetWidth;
+      curColWidth = curCol.clientWidth - padding;
+      nxtColWidth = nxtCol.clientWidth - padding;
+    });
+
+    document.addEventListener('mousemove', function(e) {
+      if (startX) {
+        var diffX = e.pageX - startX;
+        diffX = -Math.min(-diffX, curColWidth - 20);
+        diffX = Math.min(diffX, nxtColWidth - 20);
+
+        curCol.style.width = ((curColWidth + diffX) * 100 / rowWidth) + '%';
+        nxtCol.style.width = ((nxtColWidth - diffX) * 100 / rowWidth) + '%';
+        console.log(`${curColWidth + nxtColWidth} ${(curColWidth + diffX) * 100 / rowWidth + (nxtColWidth - diffX) * 100 / rowWidth}`);
+      }
+    });
+
+    document.addEventListener('mouseup', function(e) {
+      curCol = undefined;
+      nxtCol = undefined;
+      startX = undefined;
+      nxtColWidth = undefined;
+      curColWidth = undefined
+    });
+  }
+
+  function paddingDiff(col) {
+
+    if (getStyleVal(col, 'box-sizing') == 'border-box') {
+      return 0;
+    }
+
+    var padLeft = getStyleVal(col, 'padding-left');
+    var padRight = getStyleVal(col, 'padding-right');
+    return (parseInt(padLeft) + parseInt(padRight));
+
+  }
+
+  function getStyleVal(elm, css) {
+    return (window.getComputedStyle(elm, null).getPropertyValue(css))
+  }
+}
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+/* DOM manipulation and misc code */
+
+var bomsplit;
+var canvassplit;
+var initDone = false;
+var bomSortFunction = null;
+var currentSortColumn = null;
+var currentSortOrder = null;
+var currentHighlightedRowId;
+var highlightHandlers = [];
+var footprintIndexToHandler = {};
+var netsToHandler = {};
+var markedFootprints = new Set();
+var highlightedFootprints = [];
+var highlightedNet = null;
+var lastClicked;
+
+function dbg(html) {
+  dbgdiv.innerHTML = html;
+}
+
+function redrawIfInitDone() {
+  if (initDone) {
+    redrawCanvas(allcanvas.front);
+    redrawCanvas(allcanvas.back);
+  }
+}
+
+function padsVisible(value) {
+  writeStorage("padsVisible", value);
+  settings.renderPads = value;
+  redrawIfInitDone();
+}
+
+function referencesVisible(value) {
+  writeStorage("referencesVisible", value);
+  settings.renderReferences = value;
+  redrawIfInitDone();
+}
+
+function valuesVisible(value) {
+  writeStorage("valuesVisible", value);
+  settings.renderValues = value;
+  redrawIfInitDone();
+}
+
+function tracksVisible(value) {
+  writeStorage("tracksVisible", value);
+  settings.renderTracks = value;
+  redrawIfInitDone();
+}
+
+function zonesVisible(value) {
+  writeStorage("zonesVisible", value);
+  settings.renderZones = value;
+  redrawIfInitDone();
+}
+
+function dnpOutline(value) {
+  writeStorage("dnpOutline", value);
+  settings.renderDnpOutline = value;
+  redrawIfInitDone();
+}
+
+function setDarkMode(value) {
+  if (value) {
+    topmostdiv.classList.add("dark");
+  } else {
+    topmostdiv.classList.remove("dark");
+  }
+  writeStorage("darkmode", value);
+  settings.darkMode = value;
+  redrawIfInitDone();
+}
+
+function setShowBOMColumn(field, value) {
+  if (field === "references") {
+    var rl = document.getElementById("reflookup");
+    rl.disabled = !value;
+    if (!value) {
+      rl.value = "";
+      updateRefLookup("");
+    }
+  }
+
+  var n = settings.hiddenColumns.indexOf(field);
+  if (value) {
+    if (n != -1) {
+      settings.hiddenColumns.splice(n, 1);
+    }
+  } else {
+    if (n == -1) {
+      settings.hiddenColumns.push(field);
+    }
+  }
+
+  writeStorage("hiddenColumns", JSON.stringify(settings.hiddenColumns));
+
+  if (initDone) {
+    populateBomTable();
+  }
+
+  redrawIfInitDone();
+}
+
+
+function setFullscreen(value) {
+  if (value) {
+    document.documentElement.requestFullscreen();
+  } else {
+    document.exitFullscreen();
+  }
+}
+
+function fabricationVisible(value) {
+  writeStorage("fabricationVisible", value);
+  settings.renderFabrication = value;
+  redrawIfInitDone();
+}
+
+function silkscreenVisible(value) {
+  writeStorage("silkscreenVisible", value);
+  settings.renderSilkscreen = value;
+  redrawIfInitDone();
+}
+
+function setHighlightPin1(value) {
+  writeStorage("highlightpin1", value);
+  settings.highlightpin1 = value;
+  redrawIfInitDone();
+}
+
+function getStoredCheckboxRefs(checkbox) {
+  function convert(ref) {
+    var intref = parseInt(ref);
+    if (isNaN(intref)) {
+      for (var i = 0; i < pcbdata.footprints.length; i++) {
+        if (pcbdata.footprints[i].ref == ref) {
+          return i;
+        }
+      }
+      return -1;
+    } else {
+      return intref;
+    }
+  }
+  if (!(checkbox in settings.checkboxStoredRefs)) {
+    var val = readStorage("checkbox_" + checkbox);
+    settings.checkboxStoredRefs[checkbox] = val ? val : "";
+  }
+  if (!settings.checkboxStoredRefs[checkbox]) {
+    return new Set();
+  } else {
+    return new Set(settings.checkboxStoredRefs[checkbox].split(",").map(r => convert(r)).filter(a => a >= 0));
+  }
+}
+
+function getCheckboxState(checkbox, references) {
+  var storedRefsSet = getStoredCheckboxRefs(checkbox);
+  var currentRefsSet = new Set(references.map(r => r[1]));
+  // Get difference of current - stored
+  var difference = new Set(currentRefsSet);
+  for (ref of storedRefsSet) {
+    difference.delete(ref);
+  }
+  if (difference.size == 0) {
+    // All the current refs are stored
+    return "checked";
+  } else if (difference.size == currentRefsSet.size) {
+    // None of the current refs are stored
+    return "unchecked";
+  } else {
+    // Some of the refs are stored
+    return "indeterminate";
+  }
+}
+
+function setBomCheckboxState(checkbox, element, references) {
+  var state = getCheckboxState(checkbox, references);
+  element.checked = (state == "checked");
+  element.indeterminate = (state == "indeterminate");
+}
+
+function createCheckboxChangeHandler(checkbox, references, row) {
+  return function () {
+    refsSet = getStoredCheckboxRefs(checkbox);
+    var markWhenChecked = settings.markWhenChecked == checkbox;
+    eventArgs = {
+      checkbox: checkbox,
+      refs: references,
+    }
+    if (this.checked) {
+      // checkbox ticked
+      for (var ref of references) {
+        refsSet.add(ref[1]);
+      }
+      if (markWhenChecked) {
+        row.classList.add("checked");
+        for (var ref of references) {
+          markedFootprints.add(ref[1]);
+        }
+        drawHighlights();
+      }
+      eventArgs.state = 'checked';
+    } else {
+      // checkbox unticked
+      for (var ref of references) {
+        refsSet.delete(ref[1]);
+      }
+      if (markWhenChecked) {
+        row.classList.remove("checked");
+        for (var ref of references) {
+          markedFootprints.delete(ref[1]);
+        }
+        drawHighlights();
+      }
+      eventArgs.state = 'unchecked';
+    }
+    settings.checkboxStoredRefs[checkbox] = [...refsSet].join(",");
+    writeStorage("checkbox_" + checkbox, settings.checkboxStoredRefs[checkbox]);
+    updateCheckboxStats(checkbox);
+    EventHandler.emitEvent(IBOM_EVENT_TYPES.CHECKBOX_CHANGE_EVENT, eventArgs);
+  }
+}
+
+function clearHighlightedFootprints() {
+  if (currentHighlightedRowId) {
+    document.getElementById(currentHighlightedRowId).classList.remove("highlighted");
+    currentHighlightedRowId = null;
+    highlightedFootprints = [];
+    highlightedNet = null;
+  }
+}
+
+function createRowHighlightHandler(rowid, refs, net) {
+  return function () {
+    if (currentHighlightedRowId) {
+      if (currentHighlightedRowId == rowid) {
+        return;
+      }
+      document.getElementById(currentHighlightedRowId).classList.remove("highlighted");
+    }
+    document.getElementById(rowid).classList.add("highlighted");
+    currentHighlightedRowId = rowid;
+    highlightedFootprints = refs ? refs.map(r => r[1]) : [];
+    highlightedNet = net;
+    drawHighlights();
+    EventHandler.emitEvent(
+      IBOM_EVENT_TYPES.HIGHLIGHT_EVENT, {
+      rowid: rowid,
+      refs: refs,
+      net: net
+    });
+  }
+}
+
+function entryMatches(entry) {
+  if (settings.bommode == "netlist") {
+    // entry is just a net name
+    return entry.toLowerCase().indexOf(filter) >= 0;
+  }
+  // check refs
+  if (!settings.hiddenColumns.includes("references")) {
+    for (var ref of entry) {
+      if (ref[0].toLowerCase().indexOf(filter) >= 0) {
+        return true;
+      }
+    }
+  }
+  // check fields
+  for (var i in config.fields) {
+    var f = config.fields[i];
+    if (!settings.hiddenColumns.includes(f)) {
+      for (var ref of entry) {
+        if (pcbdata.bom.fields[ref[1]][i].toLowerCase().indexOf(filter) >= 0) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function findRefInEntry(entry) {
+  return entry.filter(r => r[0].toLowerCase() == reflookup);
+}
+
+function highlightFilter(s) {
+  if (!filter) {
+    return s;
+  }
+  var parts = s.toLowerCase().split(filter);
+  if (parts.length == 1) {
+    return s;
+  }
+  var r = "";
+  var pos = 0;
+  for (var i in parts) {
+    if (i > 0) {
+      r += '<mark class="highlight">' +
+        s.substring(pos, pos + filter.length) +
+        '</mark>';
+      pos += filter.length;
+    }
+    r += s.substring(pos, pos + parts[i].length);
+    pos += parts[i].length;
+  }
+  return r;
+}
+
+function checkboxSetUnsetAllHandler(checkboxname) {
+  return function () {
+    var checkboxnum = 0;
+    while (checkboxnum < settings.checkboxes.length &&
+      settings.checkboxes[checkboxnum].toLowerCase() != checkboxname.toLowerCase()) {
+      checkboxnum++;
+    }
+    if (checkboxnum >= settings.checkboxes.length) {
+      return;
+    }
+    var allset = true;
+    var checkbox;
+    var row;
+    for (row of bombody.childNodes) {
+      checkbox = row.childNodes[checkboxnum + 1].childNodes[0];
+      if (!checkbox.checked || checkbox.indeterminate) {
+        allset = false;
+        break;
+      }
+    }
+    for (row of bombody.childNodes) {
+      checkbox = row.childNodes[checkboxnum + 1].childNodes[0];
+      checkbox.checked = !allset;
+      checkbox.indeterminate = false;
+      checkbox.onchange();
+    }
+  }
+}
+
+function createColumnHeader(name, cls, comparator, is_checkbox = false) {
+  var th = document.createElement("TH");
+  th.innerHTML = name;
+  th.classList.add(cls);
+  if (is_checkbox)
+    th.setAttribute("col_name", "bom-checkbox");
+  else
+    th.setAttribute("col_name", name);
+  var span = document.createElement("SPAN");
+  span.classList.add("sortmark");
+  span.classList.add("none");
+  th.appendChild(span);
+  var spacer = document.createElement("div");
+  spacer.className = "column-spacer";
+  th.appendChild(spacer);
+  spacer.onclick = function () {
+    if (currentSortColumn && th !== currentSortColumn) {
+      // Currently sorted by another column
+      currentSortColumn.childNodes[1].classList.remove(currentSortOrder);
+      currentSortColumn.childNodes[1].classList.add("none");
+      currentSortColumn = null;
+      currentSortOrder = null;
+    }
+    if (currentSortColumn && th === currentSortColumn) {
+      // Already sorted by this column
+      if (currentSortOrder == "asc") {
+        // Sort by this column, descending order
+        bomSortFunction = function (a, b) {
+          return -comparator(a, b);
+        }
+        currentSortColumn.childNodes[1].classList.remove("asc");
+        currentSortColumn.childNodes[1].classList.add("desc");
+        currentSortOrder = "desc";
+      } else {
+        // Unsort
+        bomSortFunction = null;
+        currentSortColumn.childNodes[1].classList.remove("desc");
+        currentSortColumn.childNodes[1].classList.add("none");
+        currentSortColumn = null;
+        currentSortOrder = null;
+      }
+    } else {
+      // Sort by this column, ascending order
+      bomSortFunction = comparator;
+      currentSortColumn = th;
+      currentSortColumn.childNodes[1].classList.remove("none");
+      currentSortColumn.childNodes[1].classList.add("asc");
+      currentSortOrder = "asc";
+    }
+    populateBomBody();
+  }
+  if (is_checkbox) {
+    spacer.onclick = fancyDblClickHandler(
+      spacer, spacer.onclick, checkboxSetUnsetAllHandler(name));
+  }
+  return th;
+}
+
+function populateBomHeader(placeHolderColumn = null, placeHolderElements = null) {
+  while (bomhead.firstChild) {
+    bomhead.removeChild(bomhead.firstChild);
+  }
+  var tr = document.createElement("TR");
+  var th = document.createElement("TH");
+  th.classList.add("numCol");
+
+  var vismenu = document.createElement("div");
+  vismenu.id = "vismenu";
+  vismenu.classList.add("menu");
+
+  var visbutton = document.createElement("div");
+  visbutton.classList.add("visbtn");
+  visbutton.classList.add("hideonprint");
+
+  var viscontent = document.createElement("div");
+  viscontent.classList.add("menu-content");
+  viscontent.id = "vismenu-content";
+
+  settings.columnOrder.forEach(column => {
+    if (typeof column !== "string")
+      return;
+
+    // Skip empty columns
+    if (column === "checkboxes" && settings.checkboxes.length == 0)
+      return;
+    else if (column === "Quantity" && settings.bommode == "ungrouped")
+      return;
+
+    var label = document.createElement("label");
+    label.classList.add("menu-label");
+
+    var input = document.createElement("input");
+    input.classList.add("visibility_checkbox");
+    input.type = "checkbox";
+    input.onchange = function (e) {
+      setShowBOMColumn(column, e.target.checked)
+    };
+    input.checked = !(settings.hiddenColumns.includes(column));
+
+    label.appendChild(input);
+    if (column.length > 0)
+      label.append(column[0].toUpperCase() + column.slice(1));
+
+    viscontent.appendChild(label);
+  });
+
+  viscontent.childNodes[0].classList.add("menu-label-top");
+
+  vismenu.appendChild(visbutton);
+  if (settings.bommode != "netlist") {
+    vismenu.appendChild(viscontent);
+    th.appendChild(vismenu);
+  }
+  tr.appendChild(th);
+
+  var checkboxCompareClosure = function (checkbox) {
+    return (a, b) => {
+      var stateA = getCheckboxState(checkbox, a);
+      var stateB = getCheckboxState(checkbox, b);
+      if (stateA > stateB) return -1;
+      if (stateA < stateB) return 1;
+      return 0;
+    }
+  }
+  var stringFieldCompareClosure = function (fieldIndex) {
+    return (a, b) => {
+      var fa = pcbdata.bom.fields[a[0][1]][fieldIndex];
+      var fb = pcbdata.bom.fields[b[0][1]][fieldIndex];
+      if (fa != fb) return fa > fb ? 1 : -1;
+      else return 0;
+    }
+  }
+  var referenceRegex = /(?<prefix>[^0-9]+)(?<number>[0-9]+)/;
+  var compareRefs = (a, b) => {
+    var ra = referenceRegex.exec(a);
+    var rb = referenceRegex.exec(b);
+    if (ra === null || rb === null) {
+      if (a != b) return a > b ? 1 : -1;
+      return 0;
+    } else {
+      if (ra.groups.prefix != rb.groups.prefix) {
+        return ra.groups.prefix > rb.groups.prefix ? 1 : -1;
+      }
+      if (ra.groups.number != rb.groups.number) {
+        return parseInt(ra.groups.number) > parseInt(rb.groups.number) ? 1 : -1;
+      }
+      return 0;
+    }
+  }
+  if (settings.bommode == "netlist") {
+    th = createColumnHeader("Net name", "bom-netname", (a, b) => {
+      if (a > b) return -1;
+      if (a < b) return 1;
+      return 0;
+    });
+    tr.appendChild(th);
+  } else {
+    // Filter hidden columns
+    var columns = settings.columnOrder.filter(e => !settings.hiddenColumns.includes(e));
+    var valueIndex = config.fields.indexOf("Value");
+    var footprintIndex = config.fields.indexOf("Footprint");
+    columns.forEach((column) => {
+      if (column === placeHolderColumn) {
+        var n = 1;
+        if (column === "checkboxes")
+          n = settings.checkboxes.length;
+        for (i = 0; i < n; i++) {
+          td = placeHolderElements.shift();
+          tr.appendChild(td);
+        }
+        return;
+      } else if (column === "checkboxes") {
+        for (var checkbox of settings.checkboxes) {
+          th = createColumnHeader(
+            checkbox, "bom-checkbox", checkboxCompareClosure(checkbox), true);
+          tr.appendChild(th);
+        }
+      } else if (column === "References") {
+        tr.appendChild(createColumnHeader("References", "references", (a, b) => {
+          var i = 0;
+          while (i < a.length && i < b.length) {
+            if (a[i] != b[i]) return compareRefs(a[i][0], b[i][0]);
+            i++;
+          }
+          return a.length - b.length;
+        }));
+      } else if (column === "Value") {
+        tr.appendChild(createColumnHeader("Value", "value", (a, b) => {
+          var ra = a[0][1], rb = b[0][1];
+          return valueCompare(
+            pcbdata.bom.parsedValues[ra], pcbdata.bom.parsedValues[rb],
+            pcbdata.bom.fields[ra][valueIndex], pcbdata.bom.fields[rb][valueIndex]);
+        }));
+        return;
+      } else if (column === "Footprint") {
+        tr.appendChild(createColumnHeader(
+          "Footprint", "footprint", stringFieldCompareClosure(footprintIndex)));
+      } else if (column === "Quantity" && settings.bommode == "grouped") {
+        tr.appendChild(createColumnHeader("Quantity", "quantity", (a, b) => {
+          return a.length - b.length;
+        }));
+      } else {
+        // Other fields
+        var i = config.fields.indexOf(column);
+        if (i < 0)
+          return;
+        tr.appendChild(createColumnHeader(
+          column, `field${i + 1}`, stringFieldCompareClosure(i)));
+      }
+    });
+  }
+  bomhead.appendChild(tr);
+}
+
+function populateBomBody(placeholderColumn = null, placeHolderElements = null) {
+  while (bom.firstChild) {
+    bom.removeChild(bom.firstChild);
+  }
+  highlightHandlers = [];
+  footprintIndexToHandler = {};
+  netsToHandler = {};
+  currentHighlightedRowId = null;
+  var first = true;
+  if (settings.bommode == "netlist") {
+    bomtable = pcbdata.nets.slice();
+  } else {
+    switch (settings.canvaslayout) {
+      case 'F':
+        bomtable = pcbdata.bom.F.slice();
+        break;
+      case 'FB':
+        bomtable = pcbdata.bom.both.slice();
+        break;
+      case 'B':
+        bomtable = pcbdata.bom.B.slice();
+        break;
+    }
+    if (settings.bommode == "ungrouped") {
+      // expand bom table
+      expandedTable = []
+      for (var bomentry of bomtable) {
+        for (var ref of bomentry) {
+          expandedTable.push([ref]);
+        }
+      }
+      bomtable = expandedTable;
+    }
+  }
+  if (bomSortFunction) {
+    bomtable = bomtable.sort(bomSortFunction);
+  }
+  for (var i in bomtable) {
+    var bomentry = bomtable[i];
+    if (filter && !entryMatches(bomentry)) {
+      continue;
+    }
+    var references = null;
+    var netname = null;
+    var tr = document.createElement("TR");
+    var td = document.createElement("TD");
+    var rownum = +i + 1;
+    tr.id = "bomrow" + rownum;
+    td.textContent = rownum;
+    tr.appendChild(td);
+    if (settings.bommode == "netlist") {
+      netname = bomentry;
+      td = document.createElement("TD");
+      td.innerHTML = highlightFilter(netname ? netname : "&lt;no net&gt;");
+      tr.appendChild(td);
+    } else {
+      if (reflookup) {
+        references = findRefInEntry(bomentry);
+        if (references.length == 0) {
+          continue;
+        }
+      } else {
+        references = bomentry;
+      }
+      // Filter hidden columns
+      var columns = settings.columnOrder.filter(e => !settings.hiddenColumns.includes(e));
+      columns.forEach((column) => {
+        if (column === placeholderColumn) {
+          var n = 1;
+          if (column === "checkboxes")
+            n = settings.checkboxes.length;
+          for (i = 0; i < n; i++) {
+            td = placeHolderElements.shift();
+            tr.appendChild(td);
+          }
+          return;
+        } else if (column === "checkboxes") {
+          for (var checkbox of settings.checkboxes) {
+            if (checkbox) {
+              td = document.createElement("TD");
+              var input = document.createElement("input");
+              input.type = "checkbox";
+              input.onchange = createCheckboxChangeHandler(checkbox, references, tr);
+              setBomCheckboxState(checkbox, input, references);
+              if (input.checked && settings.markWhenChecked == checkbox) {
+                tr.classList.add("checked");
+              }
+              td.appendChild(input);
+              tr.appendChild(td);
+            }
+          }
+        } else if (column === "References") {
+          td = document.createElement("TD");
+          td.innerHTML = highlightFilter(references.map(r => r[0]).join(", "));
+          tr.appendChild(td);
+        } else if (column === "Quantity" && settings.bommode == "grouped") {
+          // Quantity
+          td = document.createElement("TD");
+          td.textContent = references.length;
+          tr.appendChild(td);
+        } else {
+          // All the other fields
+          var field_index = config.fields.indexOf(column)
+          if (field_index < 0)
+            return;
+          var valueSet = new Set();
+          references.map(r => r[1]).forEach((id) => valueSet.add(pcbdata.bom.fields[id][field_index]));
+          td = document.createElement("TD");
+          td.innerHTML = highlightFilter(Array.from(valueSet).join(", "));
+          tr.appendChild(td);
+        }
+      });
+    }
+    bom.appendChild(tr);
+    var handler = createRowHighlightHandler(tr.id, references, netname);
+    tr.onmousemove = handler;
+    highlightHandlers.push({
+      id: tr.id,
+      handler: handler,
+    });
+    if (references !== null) {
+      for (var refIndex of references.map(r => r[1])) {
+        footprintIndexToHandler[refIndex] = handler;
+      }
+    }
+    if (netname !== null) {
+      netsToHandler[netname] = handler;
+    }
+    if ((filter || reflookup) && first) {
+      handler();
+      first = false;
+    }
+  }
+  EventHandler.emitEvent(
+    IBOM_EVENT_TYPES.BOM_BODY_CHANGE_EVENT, {
+    filter: filter,
+    reflookup: reflookup,
+    checkboxes: settings.checkboxes,
+    bommode: settings.bommode,
+  });
+}
+
+function highlightPreviousRow() {
+  if (!currentHighlightedRowId) {
+    highlightHandlers[highlightHandlers.length - 1].handler();
+  } else {
+    if (highlightHandlers.length > 1 &&
+      highlightHandlers[0].id == currentHighlightedRowId) {
+      highlightHandlers[highlightHandlers.length - 1].handler();
+    } else {
+      for (var i = 0; i < highlightHandlers.length - 1; i++) {
+        if (highlightHandlers[i + 1].id == currentHighlightedRowId) {
+          highlightHandlers[i].handler();
+          break;
+        }
+      }
+    }
+  }
+  smoothScrollToRow(currentHighlightedRowId);
+}
+
+function highlightNextRow() {
+  if (!currentHighlightedRowId) {
+    highlightHandlers[0].handler();
+  } else {
+    if (highlightHandlers.length > 1 &&
+      highlightHandlers[highlightHandlers.length - 1].id == currentHighlightedRowId) {
+      highlightHandlers[0].handler();
+    } else {
+      for (var i = 1; i < highlightHandlers.length; i++) {
+        if (highlightHandlers[i - 1].id == currentHighlightedRowId) {
+          highlightHandlers[i].handler();
+          break;
+        }
+      }
+    }
+  }
+  smoothScrollToRow(currentHighlightedRowId);
+}
+
+function populateBomTable() {
+  populateBomHeader();
+  populateBomBody();
+  setBomHandlers();
+  resizableGrid(bomhead);
+}
+
+function footprintsClicked(footprintIndexes) {
+  var lastClickedIndex = footprintIndexes.indexOf(lastClicked);
+  for (var i = 1; i <= footprintIndexes.length; i++) {
+    var refIndex = footprintIndexes[(lastClickedIndex + i) % footprintIndexes.length];
+    if (refIndex in footprintIndexToHandler) {
+      lastClicked = refIndex;
+      footprintIndexToHandler[refIndex]();
+      smoothScrollToRow(currentHighlightedRowId);
+      break;
+    }
+  }
+}
+
+function netClicked(net) {
+  if (net in netsToHandler) {
+    netsToHandler[net]();
+    smoothScrollToRow(currentHighlightedRowId);
+  } else {
+    clearHighlightedFootprints();
+    highlightedNet = net;
+    drawHighlights();
+  }
+}
+
+function updateFilter(input) {
+  filter = input.toLowerCase();
+  populateBomTable();
+}
+
+function updateRefLookup(input) {
+  reflookup = input.toLowerCase();
+  populateBomTable();
+}
+
+function changeCanvasLayout(layout) {
+  document.getElementById("fl-btn").classList.remove("depressed");
+  document.getElementById("fb-btn").classList.remove("depressed");
+  document.getElementById("bl-btn").classList.remove("depressed");
+  switch (layout) {
+    case 'F':
+      document.getElementById("fl-btn").classList.add("depressed");
+      if (settings.bomlayout != "bom-only") {
+        canvassplit.collapse(1);
+      }
+      break;
+    case 'B':
+      document.getElementById("bl-btn").classList.add("depressed");
+      if (settings.bomlayout != "bom-only") {
+        canvassplit.collapse(0);
+      }
+      break;
+    default:
+      document.getElementById("fb-btn").classList.add("depressed");
+      if (settings.bomlayout != "bom-only") {
+        canvassplit.setSizes([50, 50]);
+      }
+  }
+  settings.canvaslayout = layout;
+  writeStorage("canvaslayout", layout);
+  resizeAll();
+  changeBomMode(settings.bommode);
+}
+
+function populateMetadata() {
+  document.getElementById("title").innerHTML = pcbdata.metadata.title;
+  document.getElementById("revision").innerHTML = "Rev: " + pcbdata.metadata.revision;
+  document.getElementById("company").innerHTML = pcbdata.metadata.company;
+  document.getElementById("filedate").innerHTML = pcbdata.metadata.date;
+  if (pcbdata.metadata.title != "") {
+    document.title = pcbdata.metadata.title + " BOM";
+  }
+  // Calculate board stats
+  var fp_f = 0,
+    fp_b = 0,
+    pads_f = 0,
+    pads_b = 0,
+    pads_th = 0;
+  for (var i = 0; i < pcbdata.footprints.length; i++) {
+    if (pcbdata.bom.skipped.includes(i)) continue;
+    var mod = pcbdata.footprints[i];
+    if (mod.layer == "F") {
+      fp_f++;
+    } else {
+      fp_b++;
+    }
+    for (var pad of mod.pads) {
+      if (pad.type == "th") {
+        pads_th++;
+      } else {
+        if (pad.layers.includes("F")) {
+          pads_f++;
+        }
+        if (pad.layers.includes("B")) {
+          pads_b++;
+        }
+      }
+    }
+  }
+  document.getElementById("stats-components-front").innerHTML = fp_f;
+  document.getElementById("stats-components-back").innerHTML = fp_b;
+  document.getElementById("stats-components-total").innerHTML = fp_f + fp_b;
+  document.getElementById("stats-groups-front").innerHTML = pcbdata.bom.F.length;
+  document.getElementById("stats-groups-back").innerHTML = pcbdata.bom.B.length;
+  document.getElementById("stats-groups-total").innerHTML = pcbdata.bom.both.length;
+  document.getElementById("stats-smd-pads-front").innerHTML = pads_f;
+  document.getElementById("stats-smd-pads-back").innerHTML = pads_b;
+  document.getElementById("stats-smd-pads-total").innerHTML = pads_f + pads_b;
+  document.getElementById("stats-th-pads").innerHTML = pads_th;
+  // Update version string
+  document.getElementById("github-link").innerHTML = "InteractiveHtmlBom&nbsp;" +
+    /^v\d+\.\d+/.exec(pcbdata.ibom_version)[0];
+}
+
+function changeBomLayout(layout) {
+  document.getElementById("bom-btn").classList.remove("depressed");
+  document.getElementById("lr-btn").classList.remove("depressed");
+  document.getElementById("tb-btn").classList.remove("depressed");
+  switch (layout) {
+    case 'bom-only':
+      document.getElementById("bom-btn").classList.add("depressed");
+      if (bomsplit) {
+        bomsplit.destroy();
+        bomsplit = null;
+        canvassplit.destroy();
+        canvassplit = null;
+      }
+      document.getElementById("frontcanvas").style.display = "none";
+      document.getElementById("backcanvas").style.display = "none";
+      document.getElementById("bot").style.height = "";
+      break;
+    case 'top-bottom':
+      document.getElementById("tb-btn").classList.add("depressed");
+      document.getElementById("frontcanvas").style.display = "";
+      document.getElementById("backcanvas").style.display = "";
+      document.getElementById("bot").style.height = "calc(100% - 80px)";
+      document.getElementById("bomdiv").classList.remove("split-horizontal");
+      document.getElementById("canvasdiv").classList.remove("split-horizontal");
+      document.getElementById("frontcanvas").classList.add("split-horizontal");
+      document.getElementById("backcanvas").classList.add("split-horizontal");
+      if (bomsplit) {
+        bomsplit.destroy();
+        bomsplit = null;
+        canvassplit.destroy();
+        canvassplit = null;
+      }
+      bomsplit = Split(['#bomdiv', '#canvasdiv'], {
+        sizes: [50, 50],
+        onDragEnd: resizeAll,
+        direction: "vertical",
+        gutterSize: 5
+      });
+      canvassplit = Split(['#frontcanvas', '#backcanvas'], {
+        sizes: [50, 50],
+        gutterSize: 5,
+        onDragEnd: resizeAll
+      });
+      break;
+    case 'left-right':
+      document.getElementById("lr-btn").classList.add("depressed");
+      document.getElementById("frontcanvas").style.display = "";
+      document.getElementById("backcanvas").style.display = "";
+      document.getElementById("bot").style.height = "calc(100% - 80px)";
+      document.getElementById("bomdiv").classList.add("split-horizontal");
+      document.getElementById("canvasdiv").classList.add("split-horizontal");
+      document.getElementById("frontcanvas").classList.remove("split-horizontal");
+      document.getElementById("backcanvas").classList.remove("split-horizontal");
+      if (bomsplit) {
+        bomsplit.destroy();
+        bomsplit = null;
+        canvassplit.destroy();
+        canvassplit = null;
+      }
+      bomsplit = Split(['#bomdiv', '#canvasdiv'], {
+        sizes: [50, 50],
+        onDragEnd: resizeAll,
+        gutterSize: 5
+      });
+      canvassplit = Split(['#frontcanvas', '#backcanvas'], {
+        sizes: [50, 50],
+        gutterSize: 5,
+        direction: "vertical",
+        onDragEnd: resizeAll
+      });
+  }
+  settings.bomlayout = layout;
+  writeStorage("bomlayout", layout);
+  changeCanvasLayout(settings.canvaslayout);
+}
+
+function changeBomMode(mode) {
+  document.getElementById("bom-grouped-btn").classList.remove("depressed");
+  document.getElementById("bom-ungrouped-btn").classList.remove("depressed");
+  document.getElementById("bom-netlist-btn").classList.remove("depressed");
+  var chkbxs = document.getElementsByClassName("visibility_checkbox");
+
+  switch (mode) {
+    case 'grouped':
+      document.getElementById("bom-grouped-btn").classList.add("depressed");
+      for (var i = 0; i < chkbxs.length; i++) {
+        chkbxs[i].disabled = false;
+      }
+      break;
+    case 'ungrouped':
+      document.getElementById("bom-ungrouped-btn").classList.add("depressed");
+      for (var i = 0; i < chkbxs.length; i++) {
+        chkbxs[i].disabled = false;
+      }
+      break;
+    case 'netlist':
+      document.getElementById("bom-netlist-btn").classList.add("depressed");
+      for (var i = 0; i < chkbxs.length; i++) {
+        chkbxs[i].disabled = true;
+      }
+  }
+
+  writeStorage("bommode", mode);
+  if (mode != settings.bommode) {
+    settings.bommode = mode;
+    bomSortFunction = null;
+    currentSortColumn = null;
+    currentSortOrder = null;
+    clearHighlightedFootprints();
+  }
+  populateBomTable();
+}
+
+function focusFilterField() {
+  focusInputField(document.getElementById("filter"));
+}
+
+function focusRefLookupField() {
+  focusInputField(document.getElementById("reflookup"));
+}
+
+function toggleBomCheckbox(bomrowid, checkboxnum) {
+  if (!bomrowid || checkboxnum > settings.checkboxes.length) {
+    return;
+  }
+  var bomrow = document.getElementById(bomrowid);
+  var checkbox = bomrow.childNodes[checkboxnum].childNodes[0];
+  checkbox.checked = !checkbox.checked;
+  checkbox.indeterminate = false;
+  checkbox.onchange();
+}
+
+function checkBomCheckbox(bomrowid, checkboxname) {
+  var checkboxnum = 0;
+  while (checkboxnum < settings.checkboxes.length &&
+    settings.checkboxes[checkboxnum].toLowerCase() != checkboxname.toLowerCase()) {
+    checkboxnum++;
+  }
+  if (!bomrowid || checkboxnum >= settings.checkboxes.length) {
+    return;
+  }
+  var bomrow = document.getElementById(bomrowid);
+  var checkbox = bomrow.childNodes[checkboxnum + 1].childNodes[0];
+  checkbox.checked = true;
+  checkbox.indeterminate = false;
+  checkbox.onchange();
+}
+
+function setBomCheckboxes(value) {
+  writeStorage("bomCheckboxes", value);
+  settings.checkboxes = value.split(",").map((e) => e.trim()).filter((e) => e);
+  prepCheckboxes();
+  populateMarkWhenCheckedOptions();
+  setMarkWhenChecked(settings.markWhenChecked);
+}
+
+function setMarkWhenChecked(value) {
+  writeStorage("markWhenChecked", value);
+  settings.markWhenChecked = value;
+  markedFootprints.clear();
+  for (var ref of (value ? getStoredCheckboxRefs(value) : [])) {
+    markedFootprints.add(ref);
+  }
+  populateBomTable();
+  drawHighlights();
+}
+
+function prepCheckboxes() {
+  var table = document.getElementById("checkbox-stats");
+  while (table.childElementCount > 1) {
+    table.removeChild(table.lastChild);
+  }
+  if (settings.checkboxes.length) {
+    table.style.display = "";
+  } else {
+    table.style.display = "none";
+  }
+  for (var checkbox of settings.checkboxes) {
+    var tr = document.createElement("TR");
+    var td = document.createElement("TD");
+    td.innerHTML = checkbox;
+    tr.appendChild(td);
+    td = document.createElement("TD");
+    td.id = "checkbox-stats-" + checkbox;
+    var progressbar = document.createElement("div");
+    progressbar.classList.add("bar");
+    td.appendChild(progressbar);
+    var text = document.createElement("div");
+    text.classList.add("text");
+    td.appendChild(text);
+    tr.appendChild(td);
+    table.appendChild(tr);
+    updateCheckboxStats(checkbox);
+  }
+}
+
+function populateMarkWhenCheckedOptions() {
+  var container = document.getElementById("markWhenCheckedContainer");
+
+  if (settings.checkboxes.length == 0) {
+    container.parentElement.style.display = "none";
+    return;
+  }
+
+  container.innerHTML = '';
+  container.parentElement.style.display = "inline-block";
+
+  function createOption(name, displayName) {
+    var id = "markWhenChecked-" + name;
+
+    var div = document.createElement("div");
+    div.classList.add("radio-container");
+
+    var input = document.createElement("input");
+    input.type = "radio";
+    input.name = "markWhenChecked";
+    input.value = name;
+    input.id = id;
+    input.onchange = () => setMarkWhenChecked(name);
+    div.appendChild(input);
+
+    // Preserve the selected element when the checkboxes change
+    if (name == settings.markWhenChecked) {
+      input.checked = true;
+    }
+
+    var label = document.createElement("label");
+    label.innerHTML = displayName;
+    label.htmlFor = id;
+    div.appendChild(label);
+
+    container.appendChild(div);
+  }
+  createOption("", "None");
+  for (var checkbox of settings.checkboxes) {
+    createOption(checkbox, checkbox);
+  }
+}
+
+function updateCheckboxStats(checkbox) {
+  var checked = getStoredCheckboxRefs(checkbox).size;
+  var total = pcbdata.footprints.length - pcbdata.bom.skipped.length;
+  var percent = checked * 100.0 / total;
+  var td = document.getElementById("checkbox-stats-" + checkbox);
+  td.firstChild.style.width = percent + "%";
+  td.lastChild.innerHTML = checked + "/" + total + " (" + Math.round(percent) + "%)";
+}
+
+document.onkeydown = function (e) {
+  switch (e.key) {
+    case "n":
+      if (document.activeElement.type == "text") {
+        return;
+      }
+      if (currentHighlightedRowId !== null) {
+        checkBomCheckbox(currentHighlightedRowId, "placed");
+        highlightNextRow();
+        e.preventDefault();
+      }
+      break;
+    case "ArrowUp":
+      highlightPreviousRow();
+      e.preventDefault();
+      break;
+    case "ArrowDown":
+      highlightNextRow();
+      e.preventDefault();
+      break;
+    default:
+      break;
+  }
+  if (e.altKey) {
+    switch (e.key) {
+      case "f":
+        focusFilterField();
+        e.preventDefault();
+        break;
+      case "r":
+        focusRefLookupField();
+        e.preventDefault();
+        break;
+      case "z":
+        changeBomLayout("bom-only");
+        e.preventDefault();
+        break;
+      case "x":
+        changeBomLayout("left-right");
+        e.preventDefault();
+        break;
+      case "c":
+        changeBomLayout("top-bottom");
+        e.preventDefault();
+        break;
+      case "v":
+        changeCanvasLayout("F");
+        e.preventDefault();
+        break;
+      case "b":
+        changeCanvasLayout("FB");
+        e.preventDefault();
+        break;
+      case "n":
+        changeCanvasLayout("B");
+        e.preventDefault();
+        break;
+      default:
+        break;
+    }
+    if (e.key >= '1' && e.key <= '9') {
+      toggleBomCheckbox(currentHighlightedRowId, parseInt(e.key));
+      e.preventDefault();
+    }
+  }
+}
+
+function hideNetlistButton() {
+  document.getElementById("bom-ungrouped-btn").classList.remove("middle-button");
+  document.getElementById("bom-ungrouped-btn").classList.add("right-most-button");
+  document.getElementById("bom-netlist-btn").style.display = "none";
+}
+
+window.onload = function (e) {
+  initUtils();
+  initRender();
+  initStorage();
+  initDefaults();
+  cleanGutters();
+  populateMetadata();
+  dbgdiv = document.getElementById("dbg");
+  bom = document.getElementById("bombody");
+  bomhead = document.getElementById("bomhead");
+  filter = "";
+  reflookup = "";
+  if (!("nets" in pcbdata)) {
+    hideNetlistButton();
+  }
+  initDone = true;
+  setBomCheckboxes(document.getElementById("bomCheckboxes").value);
+  // Triggers render
+  changeBomLayout(settings.bomlayout);
+
+  // Users may leave fullscreen without touching the checkbox. Uncheck.
+  document.addEventListener('fullscreenchange', () => {
+    if (!document.fullscreenElement)
+      document.getElementById('fullscreenCheckbox').checked = false;
+  });
+}
+
+window.onresize = resizeAll;
+window.matchMedia("print").addListener(resizeAll);
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+
+///////////////////////////////////////////////
+  </script>
+</head>
+
+<body>
+
+<div id="topmostdiv" class="topmostdiv">
+  <div id="top">
+    <div style="float: right; height: 100%;">
+      <div class="hideonprint menu" style="float: right; top: 8px;">
+        <button class="menubtn"></button>
+        <div class="menu-content">
+          <label class="menu-label menu-label-top" style="width: calc(50% - 18px)">
+            <input id="darkmodeCheckbox" type="checkbox" onchange="setDarkMode(this.checked)">
+            Dark mode
+          </label><!-- This comment eats space! All of it!
+          --><label class="menu-label menu-label-top" style="width: calc(50% - 17px); border-left: 0;">
+            <input id="fullscreenCheckbox" type="checkbox" onchange="setFullscreen(this.checked)">
+            Full Screen
+          </label>
+          <label class="menu-label" style="width: calc(50% - 18px)">
+            <input id="fabricationCheckbox" type="checkbox" checked onchange="fabricationVisible(this.checked)">
+            Fab layer
+          </label><!-- This comment eats space! All of it!
+          --><label class="menu-label" style="width: calc(50% - 17px); border-left: 0;">
+            <input id="silkscreenCheckbox" type="checkbox" checked onchange="silkscreenVisible(this.checked)">
+            Silkscreen
+          </label>
+          <label class="menu-label" style="width: calc(50% - 18px)">
+            <input id="referencesCheckbox" type="checkbox" checked onchange="referencesVisible(this.checked)">
+            References
+          </label><!-- This comment eats space! All of it!
+          --><label class="menu-label" style="width: calc(50% - 17px); border-left: 0;">
+            <input id="valuesCheckbox" type="checkbox" checked onchange="valuesVisible(this.checked)">
+            Values
+          </label>
+          <div id="tracksAndZonesCheckboxes">
+            <label class="menu-label" style="width: calc(50% - 18px)">
+              <input id="tracksCheckbox" type="checkbox" checked onchange="tracksVisible(this.checked)">
+              Tracks
+            </label><!-- This comment eats space! All of it!
+            --><label class="menu-label" style="width: calc(50% - 17px); border-left: 0;">
+              <input id="zonesCheckbox" type="checkbox" checked onchange="zonesVisible(this.checked)">
+              Zones
+            </label>
+          </div>
+          <label class="menu-label" style="width: calc(50% - 18px)">
+            <input id="padsCheckbox" type="checkbox" checked onchange="padsVisible(this.checked)">
+            Pads
+          </label><!-- This comment eats space! All of it!
+          --><label class="menu-label" style="width: calc(50% - 17px); border-left: 0;">
+            <input id="dnpOutlineCheckbox" type="checkbox" checked onchange="dnpOutline(this.checked)">
+            DNP outlined
+          </label>
+          <label class="menu-label">
+            <input id="highlightpin1Checkbox" type="checkbox" onchange="setHighlightPin1(this.checked)">
+            Highlight first pin
+          </label>
+          <label class="menu-label">
+            <input id="dragCheckbox" type="checkbox" checked onchange="setRedrawOnDrag(this.checked)">
+            Continuous redraw on drag
+          </label>
+          <label class="menu-label">
+            <span>Board rotation</span>
+            <span style="float: right"><span id="rotationDegree">0</span>&#176;</span>
+            <input id="boardRotation" type="range" min="-36" max="36" value="0" class="slider" oninput="setBoardRotation(this.value)">
+          </label>
+          <label class="menu-label">
+            <div style="margin-left: 5px">Bom checkboxes</div>
+            <input id="bomCheckboxes" class="menu-textbox" type=text
+                   oninput="setBomCheckboxes(this.value)">
+          </label>
+          <label class="menu-label">
+            <div style="margin-left: 5px">Mark when checked</div>
+            <div id="markWhenCheckedContainer"></div>
+          </label>
+          <label class="menu-label">
+            <span class="shameless-plug">
+              <span>Created using</span>
+              <a id="github-link" target="blank" href="https://github.com/openscopeproject/InteractiveHtmlBom">InteractiveHtmlBom</a>
+            </span>
+          </label>
+        </div>
+      </div>
+      <div class="button-container hideonprint"
+           style="float: right; position: relative; top: 8px">
+        <button id="fl-btn" class="left-most-button" onclick="changeCanvasLayout('F')"
+                title="Front only">F
+        </button>
+        <button id="fb-btn" class="middle-button" onclick="changeCanvasLayout('FB')"
+                title="Front and Back">FB
+        </button>
+        <button id="bl-btn" class="right-most-button" onclick="changeCanvasLayout('B')"
+                title="Back only">B
+        </button>
+      </div>
+      <div class="button-container hideonprint"
+           style="float: right; position: relative; top: 8px">
+        <button id="bom-btn" class="left-most-button" onclick="changeBomLayout('bom-only')"
+                title="BOM only"></button>
+        <button id="lr-btn" class="middle-button" onclick="changeBomLayout('left-right')"
+                title="BOM left, drawings right"></button>
+        <button id="tb-btn" class="right-most-button" onclick="changeBomLayout('top-bottom')"
+                title="BOM top, drawings bot"></button>
+      </div>
+      <div class="button-container hideonprint"
+           style="float: right; position: relative; top: 8px">
+        <button id="bom-grouped-btn" class="left-most-button" onclick="changeBomMode('grouped')"
+                title="Grouped BOM"></button>
+        <button id="bom-ungrouped-btn" class="middle-button" onclick="changeBomMode('ungrouped')"
+                title="Ungrouped BOM"></button>
+        <button id="bom-netlist-btn" class="right-most-button" onclick="changeBomMode('netlist')"
+                title="Netlist"></button>
+      </div>
+      <div class="hideonprint menu" style="float: right; top: 8px;">
+        <button class="statsbtn"></button>
+        <div class="menu-content">
+          <table class="stats">
+            <tbody>
+              <tr>
+                <td width="40%">Board stats</td>
+                <td>Front</td>
+                <td>Back</td>
+                <td>Total</td>
+              </tr>
+              <tr>
+                <td>Components</td>
+                <td id="stats-components-front">~</td>
+                <td id="stats-components-back">~</td>
+                <td id="stats-components-total">~</td>
+              </tr>
+              <tr>
+                <td>Groups</td>
+                <td id="stats-groups-front">~</td>
+                <td id="stats-groups-back">~</td>
+                <td id="stats-groups-total">~</td>
+              </tr>
+              <tr>
+                <td>SMD pads</td>
+                <td id="stats-smd-pads-front">~</td>
+                <td id="stats-smd-pads-back">~</td>
+                <td id="stats-smd-pads-total">~</td>
+              </tr>
+              <tr>
+                <td>TH pads</td>
+                <td colspan=3 id="stats-th-pads">~</td>
+              </tr>
+            </tbody>
+          </table>
+          <table class="stats">
+            <col width="40%"/><col />
+            <tbody id="checkbox-stats">
+              <tr>
+                <td colspan=2 style="border-top: 0">Checkboxes</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="hideonprint menu" style="float: right; top: 8px;">
+        <button class="iobtn"></button>
+        <div class="menu-content">
+          <div class="menu-label menu-label-top">
+            <div style="margin-left: 5px;">Save board image</div>
+            <div class="flexbox">
+              <input id="render-save-width" class="menu-textbox" type="text" value="1000" placeholder="Width"
+                  style="flex-grow: 1; width: 50px;" oninput="validateSaveImgDimension(this)">
+              <span>X</span>
+              <input id="render-save-height" class="menu-textbox" type="text" value="1000" placeholder="Height"
+                  style="flex-grow: 1; width: 50px;" oninput="validateSaveImgDimension(this)">
+            </div>
+            <label>
+              <input id="render-save-transparent" type="checkbox">
+              Transparent background
+            </label>
+            <div class="flexbox">
+              <button class="savebtn" onclick="saveImage('F')">Front</button>
+              <button class="savebtn" onclick="saveImage('B')">Back</button>
+            </div>
+          </div>
+          <div class="menu-label">
+            <span style="margin-left: 5px;">Config and checkbox state</span>
+            <div class="flexbox">
+              <button class="savebtn" onclick="saveSettings()">Export</button>
+              <button class="savebtn" onclick="loadSettings()">Import</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="fileinfodiv" style="overflow: auto;">
+      <table class="fileinfo">
+        <tbody>
+          <tr>
+            <td id="title" class="title" style="width: 70%">
+              Title
+            </td>
+            <td id="revision" class="title" style="width: 30%">
+              Revision
+            </td>
+          </tr>
+          <tr>
+            <td id="company">
+              Company
+            </td>
+            <td id="filedate">
+              Date
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div id="bot" class="split" style="height: calc(100% - 80px)">
+    <div id="bomdiv" class="split split-horizontal">
+      <div style="width: 100%">
+        <input id="reflookup" class="textbox searchbox reflookup hideonprint" type="text" placeholder="Ref lookup"
+               oninput="updateRefLookup(this.value)">
+        <input id="filter" class="textbox searchbox filter hideonprint" type="text" placeholder="Filter"
+               oninput="updateFilter(this.value)">
+        <div class="button-container hideonprint" style="float: left; margin: 0;">
+          <button id="copy" title="Copy bom table to clipboard"
+               onclick="copyToClipboard()"></button>
+        </div>
+      </div>
+      <div id="dbg"></div>
+      <table class="bom" id="bomtable">
+        <thead id="bomhead">
+        </thead>
+        <tbody id="bombody">
+        </tbody>
+      </table>
+    </div>
+    <div id="canvasdiv" class="split split-horizontal">
+      <div id="frontcanvas" class="split" touch-action="none" style="overflow: hidden">
+        <div style="position: relative; width: 100%; height: 100%;">
+          <canvas id="F_bg" style="position: absolute; left: 0; top: 0; z-index: 0;"></canvas>
+          <canvas id="F_fab" style="position: absolute; left: 0; top: 0; z-index: 1;"></canvas>
+          <canvas id="F_slk" style="position: absolute; left: 0; top: 0; z-index: 2;"></canvas>
+          <canvas id="F_hl" style="position: absolute; left: 0; top: 0; z-index: 3;"></canvas>
+        </div>
+      </div>
+      <div id="backcanvas" class="split" touch-action="none" style="overflow: hidden">
+        <div style="position: relative; width: 100%; height: 100%;">
+          <canvas id="B_bg" style="position: absolute; left: 0; top: 0; z-index: 0;"></canvas>
+          <canvas id="B_fab" style="position: absolute; left: 0; top: 0; z-index: 1;"></canvas>
+          <canvas id="B_slk" style="position: absolute; left: 0; top: 0; z-index: 2;"></canvas>
+          <canvas id="B_hl" style="position: absolute; left: 0; top: 0; z-index: 3;"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #2. 

I reverse-engineered the commands required to generate the BOM and generated one for 0.03.12 matching the style of the one we had for the 0.03.10. For a quick preview for review [this handy github.io rendering of the PR html file can be used](http://htmlpreview.github.io/?https://github.com/gluap/OpenBikeSensor_PCB_Board/blob/merged/OpenBikeSensor03/generated/BOM_for_soldering_Rev_0.03.12.html).

The steps I needed to generate the BOM were:
- from EEschema: Write out bom grouped by value (spawns an XML file with the BOM and extra fields)
- ``git clone https://github.com/openscopeproject/InteractiveHtmlBom`` to ``$SOMEWHERE`` (choose your poison. Ideally not within the PCB repo dir)
- run ``python3 $SOMEWHERE/InteractiveHtmlBom/InteractiveHtmlBom/generate_interactive_bom.py OpenBikeSensor03.kicad_pcb  --show-dialog``, import xml in the fields tab, adapt field order.